### PR TITLE
polish(web): empty + loading + error states, scope-grants explainer

### DIFF
--- a/web/server/package.json
+++ b/web/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraclaw/web-server",
-  "version": "0.0.1",
+  "version": "0.0.2-rc.1",
   "private": true,
   "description": "Paraclaw web UI server. Lists agent groups + manages vault attachments. Reuses NanoClaw's better-sqlite3 + Parachute attach helpers.",
   "license": "AGPL-3.0",

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraclaw/web-ui",
-  "version": "0.0.1",
+  "version": "0.0.2-rc.1",
   "private": true,
   "description": "Paraclaw web UI — Vite + React + TypeScript. Manages vault attachments per agent group.",
   "license": "AGPL-3.0",

--- a/web/ui/src/routes/GroupDetail.tsx
+++ b/web/ui/src/routes/GroupDetail.tsx
@@ -14,6 +14,37 @@ const SCOPE_OPTIONS: { value: VaultScope; label: string }[] = [
   { value: "vault:admin", label: "vault:admin — full access (use sparingly)" },
 ];
 
+const READ_TOOLS = ["query-notes", "list-tags", "find-path", "vault-info"] as const;
+const WRITE_TOOLS = ["create-note", "update-note", "delete-note", "update-tag", "delete-tag"] as const;
+
+function scopeGrants(scope: VaultScope): {
+  summary: string;
+  granted: readonly string[];
+  withheld: readonly string[];
+  adminNote?: string;
+} {
+  if (scope === "vault:read") {
+    return {
+      summary: "Read-only access. The agent can query the vault but cannot create, modify, or delete anything.",
+      granted: READ_TOOLS,
+      withheld: WRITE_TOOLS,
+    };
+  }
+  if (scope === "vault:write") {
+    return {
+      summary: "Read + write. The agent can capture and update notes and tags, but cannot manage vault config or tokens.",
+      granted: [...READ_TOOLS, ...WRITE_TOOLS],
+      withheld: [],
+    };
+  }
+  return {
+    summary: "Full access including vault config (/.parachute/config*) and token management. Use sparingly.",
+    granted: [...READ_TOOLS, ...WRITE_TOOLS],
+    withheld: [],
+    adminNote: "Admin tokens can read and write any path including vault config — only grant when the agent genuinely needs it.",
+  };
+}
+
 export function GroupDetail() {
   const { folder } = useParams<{ folder: string }>();
   const [group, setGroup] = useState<AgentGroupView | null>(null);
@@ -104,7 +135,17 @@ export function GroupDetail() {
   };
 
   if (loading && !group) {
-    return <div className="status-banner">Loading {folder}…</div>;
+    return (
+      <div>
+        <Link to="/" className="muted">← All groups</Link>
+        <div className="skeleton skeleton-heading" style={{ marginTop: "1rem" }} />
+        <div className="section">
+          <div className="skeleton skeleton-line" style={{ width: "30%" }} />
+          <div className="skeleton skeleton-line" />
+          <div className="skeleton skeleton-line" style={{ width: "70%" }} />
+        </div>
+      </div>
+    );
   }
 
   if (error) {
@@ -112,6 +153,11 @@ export function GroupDetail() {
       <div>
         <Link to="/" className="muted">← All groups</Link>
         <div className="error-banner" style={{ marginTop: "1rem" }}>{error}</div>
+        <div className="actions" style={{ marginTop: "1rem" }}>
+          <button onClick={reload} disabled={loading}>
+            {loading ? "Retrying…" : "Retry"}
+          </button>
+        </div>
       </div>
     );
   }
@@ -209,6 +255,7 @@ export function GroupDetail() {
               <p className="dim">
                 Token capability — the agent literally cannot exceed this. Default <code>vault:read</code>.
               </p>
+              <ScopeGrants scope={scope} />
             </div>
 
             <div className="row">
@@ -277,6 +324,42 @@ export function GroupDetail() {
           .)
         </p>
       </div>
+    </div>
+  );
+}
+
+function ScopeGrants({ scope }: { scope: VaultScope }) {
+  const grants = scopeGrants(scope);
+  return (
+    <div className="scope-grants">
+      <p className="scope-grants-summary">{grants.summary}</p>
+      <div className="scope-grants-tools">
+        <div>
+          <span className="scope-grants-label">Allows</span>
+          <ul>
+            {grants.granted.map((t) => (
+              <li key={t}>
+                <code>{t}</code>
+              </li>
+            ))}
+          </ul>
+        </div>
+        {grants.withheld.length > 0 && (
+          <div>
+            <span className="scope-grants-label">Blocks</span>
+            <ul>
+              {grants.withheld.map((t) => (
+                <li key={t} className="dim">
+                  <code>{t}</code>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+      {grants.adminNote && (
+        <p className="scope-grants-warn">{grants.adminNote}</p>
+      )}
     </div>
   );
 }

--- a/web/ui/src/routes/GroupList.tsx
+++ b/web/ui/src/routes/GroupList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { listGroups, type AgentGroupView } from "../lib/api.ts";
 
@@ -8,6 +8,12 @@ export function GroupList() {
     | { kind: "ok"; groups: AgentGroupView[] }
     | { kind: "error"; message: string }
   >({ kind: "loading" });
+  const [reloadKey, setReloadKey] = useState(0);
+
+  const reload = useCallback(() => {
+    setState({ kind: "loading" });
+    setReloadKey((k) => k + 1);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -24,25 +30,38 @@ export function GroupList() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [reloadKey]);
 
   if (state.kind === "loading") {
-    return <div className="status-banner">Loading agent groups…</div>;
+    return (
+      <div>
+        <h2>Agent groups</h2>
+        <ul className="skeleton-list" aria-busy="true" aria-label="Loading agent groups">
+          <li className="skeleton skeleton-row" />
+          <li className="skeleton skeleton-row" />
+          <li className="skeleton skeleton-row" />
+        </ul>
+      </div>
+    );
   }
 
   if (state.kind === "error") {
     return (
       <div>
+        <h2>Agent groups</h2>
         <div className="error-banner">
           Couldn't load groups: <code>{state.message}</code>
         </div>
         <p className="muted">
           Make sure the web server is running:{" "}
-          <code>pnpm --filter @paraclaw/web-server dev</code>. It needs the
+          <code>cd web/server &amp;&amp; pnpm dev</code>. It needs the
           NanoClaw central DB at <code>data/v2.db</code> — that gets created
           the first time you run <code>pnpm setup</code> or{" "}
-          <code>pnpm dev</code>.
+          <code>pnpm dev</code> from the repo root.
         </p>
+        <div className="actions" style={{ marginTop: "1rem" }}>
+          <button onClick={reload}>Retry</button>
+        </div>
       </div>
     );
   }
@@ -51,13 +70,34 @@ export function GroupList() {
     return (
       <div>
         <h2>Agent groups</h2>
-        <div className="empty">
-          <p>No agent groups yet.</p>
-          <p className="dim">
-            NanoClaw spawns agent groups via channel skills (e.g.{" "}
-            <code>/init-first-agent</code>) or the setup flow. Once you have
-            one, refresh this page to manage its vault attachment here.
+        <div className="empty empty-rich">
+          <p className="empty-headline">No agent groups yet.</p>
+          <p className="muted">
+            Paraclaw will spin up agent groups from here soon
+            {" "}
+            (
+            <a
+              href="https://github.com/ParachuteComputer/paraclaw/issues/1"
+              target="_blank"
+              rel="noreferrer"
+            >
+              #1: new-agent wizard
+            </a>
+            ). Until then, bootstrap your first group via:
           </p>
+          <ul className="empty-paths">
+            <li>
+              <strong>Claude Code skill</strong> —
+              run <code>/init-first-agent</code> to walk through channel pick + identity + welcome DM.
+            </li>
+            <li>
+              <strong>CLI setup</strong> —
+              run <code>pnpm setup</code> from the repo root.
+            </li>
+          </ul>
+          <div className="actions" style={{ justifyContent: "center", marginTop: "1rem" }}>
+            <button className="secondary" onClick={reload}>Refresh</button>
+          </div>
         </div>
       </div>
     );

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -203,3 +203,97 @@ form .actions { display: flex; gap: 0.6rem; align-items: center; }
 .kv code { word-break: break-all; }
 
 hr.sep { border: 0; border-top: 1px solid var(--border); margin: 1.5rem 0; }
+
+/* Skeleton loaders */
+@keyframes skeleton-shimmer {
+  0% { background-position: -400px 0; }
+  100% { background-position: 400px 0; }
+}
+.skeleton {
+  background: linear-gradient(
+    90deg,
+    var(--bg-soft) 0%,
+    #ece8df 50%,
+    var(--bg-soft) 100%
+  );
+  background-size: 800px 100%;
+  animation: skeleton-shimmer 1.4s linear infinite;
+  border-radius: 6px;
+}
+.skeleton-list { list-style: none; padding: 0; margin: 0; }
+.skeleton-row { height: 4.5rem; margin-bottom: 0.75rem; }
+.skeleton-heading { height: 1.6rem; width: 40%; margin-bottom: 1rem; }
+.skeleton-line { height: 0.9rem; margin-bottom: 0.6rem; width: 100%; }
+
+/* Richer empty state */
+.empty-rich { text-align: left; padding: 2rem 1.75rem; background: white; border: 1px solid var(--border); }
+.empty-rich .empty-headline { font-size: 1.05rem; color: var(--fg); margin: 0 0 0.5rem; font-weight: 500; }
+.empty-paths {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.6rem;
+}
+.empty-paths li {
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  padding: 0.7rem 0.9rem;
+  border-radius: 8px;
+  font-size: 0.92rem;
+  color: var(--fg-muted);
+}
+.empty-paths li strong { color: var(--fg); margin-right: 0.4rem; font-weight: 500; }
+
+/* Scope grants explainer */
+.scope-grants {
+  margin-top: 0.75rem;
+  padding: 0.85rem 1rem;
+  background: var(--bg-soft);
+  border-left: 3px solid var(--accent);
+  border-radius: 4px;
+}
+.scope-grants-summary {
+  margin: 0 0 0.6rem;
+  font-size: 0.88rem;
+  color: var(--fg);
+}
+.scope-grants-tools {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+.scope-grants-tools > div:only-child { grid-column: 1 / -1; }
+.scope-grants-label {
+  display: block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-muted);
+  margin-bottom: 0.25rem;
+  font-weight: 500;
+}
+.scope-grants-tools ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+.scope-grants-tools li code {
+  font-size: 0.78rem;
+  background: white;
+  border: 1px solid var(--border);
+  padding: 0.15em 0.45em;
+}
+.scope-grants-tools li.dim code {
+  background: transparent;
+  color: var(--fg-dim);
+  text-decoration: line-through;
+}
+.scope-grants-warn {
+  margin: 0.75rem 0 0;
+  font-size: 0.82rem;
+  color: var(--warn);
+}


### PR DESCRIPTION
## Summary

- Empty state on `GroupList` now points operators at the new-agent-wizard (#1) and explains the two paths to bootstrap a group today (`/init-first-agent` skill, `pnpm setup`). Replaces the bare "No agent groups yet" message.
- Skeleton loading rows on both `GroupList` and `GroupDetail` (CSS-only shimmer, no new deps).
- Retry buttons on every error path so the operator doesn't have to hard-refresh.
- Fix misleading `pnpm --filter @paraclaw/web-server dev` in the error hint — paraclaw isn't a pnpm workspace; the actual command is `cd web/server && pnpm dev`.
- New scope-grants explainer under the scope picker on the attach form: shows exactly which of the nine vault tools each scope unlocks (read = 4 read tools; write = read + 5 write tools; admin = all + vault config), with a warn-styled note for admin tokens.
- New CSS: skeleton shimmer keyframe, `.empty-rich`, `.scope-grants*` families.
- Bump `@paraclaw/web-server` and `@paraclaw/web-ui` to `0.0.2-rc.1`.

## Why

Aaron blessed empty-state polish in parallel with him registering a real agent group. This PR is everything testable without populated data: the empty path, error paths, loading path, and the part of the attach flow that doesn't require a real group to render (the scope picker explainer is rendered into the attach form when it's eventually shown).

The scope picker change is the load-bearing operator-trust improvement. The token capability boundary becomes obvious before the operator clicks "Attach" — `vault:admin` is now visibly different from `vault:write` (an explicit warn note + the admin-only config-path mention).

## Test plan

- [x] `pnpm typecheck` (web/ui + web/server) — clean.
- [x] `pnpm build` (web/ui) — succeeds; bundle CSS grew from 4.1kB to 5.92kB (gzip 1.78kB).
- [x] Built bundle served by the running web server; `curl` confirms new CSS classes (`skeleton`, `skeleton-row`, `skeleton-heading`, `skeleton-line`, `empty-rich`, `empty-paths`, `scope-grants`, `scope-grants-summary`, `scope-grants-tools`, `scope-grants-label`, `scope-grants-warn`, `@keyframes skeleton-shimmer`) are all present in the prod CSS.
- [x] JS bundle confirmed to ship the new strings (`Retry`, `Refresh`, `scope-grants`, `Read-only access`, `Read + write`, `Full access including`, `issues/1`).
- [ ] **In-browser smoke** — pending Aaron registering an agent group; the empty path works without one. The detail-page paths (loading skeleton, scope-grants block, retry on error) need a real group to fully exercise. Smoke during PR review.

## Scope boundaries

- No upstream NanoClaw files touched.
- No changes to the integration layer (`src/parachute/`).
- No changes to the server. UI-only PR plus version bumps on both packages (server bump signals the matching release line; the server itself is unchanged but ships paired with the UI).

## Out of scope (separate issues)

- New-agent wizard — #1 (the next PR).
- Channel adapter install via UI — #2.
- Provider install via UI — #3.
- Operator auth — #4 (blocked on hub#58).
- Live agent-group status — #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)