### PR TITLE
feat(web): new-agent wizard — create agent groups end-to-end (closes #1)

### DIFF
--- a/src/parachute/create-agent.ts
+++ b/src/parachute/create-agent.ts
@@ -11,10 +11,7 @@
  * (`init-first-agent.ts` etc.) stay on the same NanoClaw helpers and are
  * untouched.
  */
-import {
-  createAgentGroup as dbCreateAgentGroup,
-  getAgentGroupByFolder,
-} from '../db/agent-groups.js';
+import { createAgentGroup as dbCreateAgentGroup, getAgentGroupByFolder } from '../db/agent-groups.js';
 import { initGroupFilesystem } from '../group-init.js';
 import { normalizeName } from '../modules/agent-to-agent/db/agent-destinations.js';
 import type { AgentGroup } from '../types.js';
@@ -42,8 +39,7 @@ export function validateFolderSlug(slug: string): FolderValidation {
   if (!FOLDER_RE.test(slug)) {
     return {
       ok: false,
-      reason:
-        'folder slug must be lowercase letters, digits, and dashes; cannot start or end with a dash',
+      reason: 'folder slug must be lowercase letters, digits, and dashes; cannot start or end with a dash',
     };
   }
   return { ok: true };

--- a/src/parachute/create-agent.ts
+++ b/src/parachute/create-agent.ts
@@ -1,0 +1,129 @@
+/**
+ * Create a Parachute agent group from a single call.
+ *
+ * Wraps NanoClaw's central-DB write (`createAgentGroup`) and on-disk init
+ * (`initGroupFilesystem`) into one shim, with optional inline vault
+ * attachment via `attachVaultToGroup`. Channel wiring is intentionally NOT
+ * here — the wizard creates a channel-less group; channel install is its
+ * own surface (paraclaw#2).
+ *
+ * The shim is the seam the web server uses; the existing CLI scripts
+ * (`init-first-agent.ts` etc.) stay on the same NanoClaw helpers and are
+ * untouched.
+ */
+import {
+  createAgentGroup as dbCreateAgentGroup,
+  getAgentGroupByFolder,
+} from '../db/agent-groups.js';
+import { initGroupFilesystem } from '../group-init.js';
+import { normalizeName } from '../modules/agent-to-agent/db/agent-destinations.js';
+import type { AgentGroup } from '../types.js';
+
+import type { VaultAttachment, VaultScope } from './types.js';
+import { attachVaultToGroup, readVaultAttachment } from './vault-mcp.js';
+
+const FOLDER_RE = /^[a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])?$/;
+const FOLDER_MAX = 48;
+
+export interface FolderValidationOk {
+  ok: true;
+}
+export interface FolderValidationFail {
+  ok: false;
+  reason: string;
+}
+export type FolderValidation = FolderValidationOk | FolderValidationFail;
+
+export function validateFolderSlug(slug: string): FolderValidation {
+  if (!slug) return { ok: false, reason: 'folder slug is required' };
+  if (slug.length > FOLDER_MAX) {
+    return { ok: false, reason: `folder slug must be ≤ ${FOLDER_MAX} chars` };
+  }
+  if (!FOLDER_RE.test(slug)) {
+    return {
+      ok: false,
+      reason:
+        'folder slug must be lowercase letters, digits, and dashes; cannot start or end with a dash',
+    };
+  }
+  return { ok: true };
+}
+
+export function suggestFolderSlug(name: string): string {
+  return normalizeName(name).slice(0, FOLDER_MAX);
+}
+
+export function isFolderTaken(folder: string): boolean {
+  return getAgentGroupByFolder(folder) !== undefined;
+}
+
+export interface CreateAgentGroupVaultOpts {
+  scope: VaultScope;
+  vaultBaseUrl?: string;
+  tokenLabel?: string;
+  /** If absent, callers higher up the stack mint via `parachute vault tokens create`. */
+  token: string;
+  mcpName?: string;
+  instructions?: string;
+}
+
+export interface CreateAgentGroupOpts {
+  name: string;
+  folder: string;
+  instructions?: string;
+  /** Optional inline vault attachment. The token must already be in hand. */
+  vault?: CreateAgentGroupVaultOpts;
+}
+
+export interface CreateAgentGroupResult {
+  group: AgentGroup;
+  vault: VaultAttachment | null;
+}
+
+/**
+ * Create a new agent group: validate, write DB row, initialize filesystem,
+ * optionally attach a vault. NOT idempotent — `isFolderTaken` is the gate
+ * the caller must check; this throws if the folder already exists.
+ */
+export function createParachuteAgentGroup(opts: CreateAgentGroupOpts): CreateAgentGroupResult {
+  const folderCheck = validateFolderSlug(opts.folder);
+  if (!folderCheck.ok) {
+    throw new Error(`invalid folder slug: ${folderCheck.reason}`);
+  }
+  const trimmedName = opts.name.trim();
+  if (!trimmedName) {
+    throw new Error('agent name is required');
+  }
+  if (isFolderTaken(opts.folder)) {
+    throw new Error(`agent group folder already exists: ${opts.folder}`);
+  }
+
+  const id = `ag-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const created_at = new Date().toISOString();
+  const group: AgentGroup = {
+    id,
+    name: trimmedName,
+    folder: opts.folder,
+    agent_provider: null,
+    created_at,
+  };
+
+  dbCreateAgentGroup(group);
+  initGroupFilesystem(group, { instructions: opts.instructions });
+
+  let vault: VaultAttachment | null = null;
+  if (opts.vault) {
+    attachVaultToGroup({
+      folder: group.folder,
+      vaultBaseUrl: opts.vault.vaultBaseUrl ?? 'http://127.0.0.1:1940/vault/default',
+      vaultToken: opts.vault.token,
+      scope: opts.vault.scope,
+      tokenLabel: opts.vault.tokenLabel ?? `claw-${group.folder}`,
+      mcpName: opts.vault.mcpName,
+      instructions: opts.vault.instructions,
+    });
+    vault = readVaultAttachment(group.folder, opts.vault.mcpName);
+  }
+
+  return { group, vault };
+}

--- a/web/server/package.json
+++ b/web/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraclaw/web-server",
-  "version": "0.0.2-rc.1",
+  "version": "0.0.3-rc.1",
   "private": true,
   "description": "Paraclaw web UI server. Lists agent groups + manages vault attachments. Reuses NanoClaw's better-sqlite3 + Parachute attach helpers.",
   "license": "AGPL-3.0",

--- a/web/server/src/server.ts
+++ b/web/server/src/server.ts
@@ -27,6 +27,8 @@ import { fileURLToPath } from 'node:url';
 import Database from 'better-sqlite3';
 
 import { DATA_DIR, GROUPS_DIR } from '../../../src/config.js';
+import { initDb } from '../../../src/db/connection.js';
+import { runMigrations } from '../../../src/db/migrations/index.js';
 import {
   attachVaultToGroup,
   detachVaultFromGroup,
@@ -34,6 +36,12 @@ import {
   DEFAULT_VAULT_MCP_NAME,
 } from '../../../src/parachute/vault-mcp.js';
 import type { VaultScope } from '../../../src/parachute/types.js';
+import {
+  createParachuteAgentGroup,
+  isFolderTaken,
+  suggestFolderSlug,
+  validateFolderSlug,
+} from '../../../src/parachute/create-agent.js';
 
 const CENTRAL_DB_PATH = path.join(DATA_DIR, 'v2.db');
 
@@ -41,6 +49,14 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const UI_DIST = path.resolve(__dirname, '../../ui/dist');
 const PORT = Number(process.env.PARACLAW_WEB_PORT ?? 4944);
 const HOST = process.env.PARACLAW_WEB_BIND ?? '127.0.0.1';
+
+// NanoClaw's mutating helpers (createAgentGroup, etc.) talk to a
+// process-singleton DB connection (`getDb`). Initialize it once at boot so
+// the wizard endpoint can write. WAL mode + foreign_keys ON are set inside.
+// Concurrent with a running NanoClaw service (also WAL) is fine — SQLite
+// handles multiple writers per file. Migrations are idempotent.
+const centralDb = initDb(CENTRAL_DB_PATH);
+runMigrations(centralDb);
 
 interface AgentGroupRow {
   id: string;
@@ -174,7 +190,7 @@ async function handleApi(
   if (pathname === '/api/health' && method === 'GET') {
     json(res, 200, {
       service: 'paraclaw-web-server',
-      version: '0.0.1',
+      version: '0.0.3-rc.1',
       data_dir: DATA_DIR,
       groups_dir: GROUPS_DIR,
     });
@@ -188,6 +204,100 @@ async function handleApi(
     } catch (err) {
       error(res, 500, err instanceof Error ? err.message : String(err));
     }
+    return;
+  }
+
+  if (pathname === '/api/groups' && method === 'POST') {
+    try {
+      const body = await readJsonBody<{
+        name?: string;
+        folder?: string;
+        instructions?: string;
+        vault?: {
+          scope?: string;
+          vaultBaseUrl?: string;
+          tokenLabel?: string;
+          token?: string;
+          mcpName?: string;
+        };
+      }>(req);
+
+      const name = (body.name ?? '').trim();
+      const folder = (body.folder ?? '').trim();
+      if (!name) {
+        error(res, 400, 'name is required');
+        return;
+      }
+      const folderCheck = validateFolderSlug(folder);
+      if (!folderCheck.ok) {
+        error(res, 400, folderCheck.reason);
+        return;
+      }
+      if (isFolderTaken(folder)) {
+        error(res, 409, `agent group folder already exists: ${folder}`);
+        return;
+      }
+
+      let vaultArg:
+        | Parameters<typeof createParachuteAgentGroup>[0]['vault']
+        | undefined;
+      let mintedVaultToken = false;
+      if (body.vault) {
+        const scope = (body.vault.scope ?? 'vault:read') as VaultScope;
+        if (!VALID_SCOPES.includes(scope)) {
+          error(res, 400, `invalid vault.scope: ${scope}`);
+          return;
+        }
+        const tokenLabel = body.vault.tokenLabel ?? `claw-${folder}`;
+        let token = body.vault.token;
+        if (!token) {
+          const minted = await mintVaultToken({ scope, label: tokenLabel });
+          token = minted.token;
+          mintedVaultToken = true;
+        }
+        vaultArg = {
+          scope,
+          vaultBaseUrl: body.vault.vaultBaseUrl,
+          tokenLabel,
+          token,
+          mcpName: body.vault.mcpName,
+        };
+      }
+
+      const created = createParachuteAgentGroup({
+        name,
+        folder,
+        instructions: body.instructions?.trim() || undefined,
+        vault: vaultArg,
+      });
+
+      const view = getAgentGroup(created.group.folder);
+      json(res, 201, { group: view, mintedVaultToken });
+    } catch (err) {
+      error(res, 500, err instanceof Error ? err.message : String(err));
+    }
+    return;
+  }
+
+  // GET /api/folder-availability/:slug — used by the new-agent wizard for
+  // live "is this slug free?" feedback.
+  const folderAvail = pathname.match(/^\/api\/folder-availability\/([^/]+)$/);
+  if (folderAvail && method === 'GET') {
+    const slug = decodeURIComponent(folderAvail[1]);
+    const v = validateFolderSlug(slug);
+    if (!v.ok) {
+      json(res, 200, { slug, valid: false, available: false, reason: v.reason });
+      return;
+    }
+    json(res, 200, { slug, valid: true, available: !isFolderTaken(slug) });
+    return;
+  }
+
+  // GET /api/folder-suggestion?name=... — wizard uses this to seed the slug
+  // input from the agent name.
+  if (pathname === '/api/folder-suggestion' && method === 'GET') {
+    const name = url.searchParams.get('name') ?? '';
+    json(res, 200, { name, slug: suggestFolderSlug(name) });
     return;
   }
 

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraclaw/web-ui",
-  "version": "0.0.2-rc.1",
+  "version": "0.0.3-rc.1",
   "private": true,
   "description": "Paraclaw web UI — Vite + React + TypeScript. Manages vault attachments per agent group.",
   "license": "AGPL-3.0",

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -1,6 +1,7 @@
 import { Link, Route, Routes } from "react-router-dom";
 import { GroupList } from "./routes/GroupList.tsx";
 import { GroupDetail } from "./routes/GroupDetail.tsx";
+import { NewGroupWizard } from "./routes/NewGroupWizard.tsx";
 
 export function App() {
   return (
@@ -21,6 +22,7 @@ export function App() {
 
       <Routes>
         <Route path="/" element={<GroupList />} />
+        <Route path="/groups/new" element={<NewGroupWizard />} />
         <Route path="/groups/:folder" element={<GroupDetail />} />
         <Route path="*" element={<div className="empty">404 — back to <Link to="/">groups</Link>.</div>} />
       </Routes>

--- a/web/ui/src/components/ScopeGrants.tsx
+++ b/web/ui/src/components/ScopeGrants.tsx
@@ -1,0 +1,74 @@
+import type { VaultScope } from "../lib/api.ts";
+
+const READ_TOOLS = ["query-notes", "list-tags", "find-path", "vault-info"] as const;
+const WRITE_TOOLS = ["create-note", "update-note", "delete-note", "update-tag", "delete-tag"] as const;
+
+export const SCOPE_OPTIONS: { value: VaultScope; label: string }[] = [
+  { value: "vault:read", label: "vault:read — query, can't modify" },
+  { value: "vault:write", label: "vault:write — capture and update notes" },
+  { value: "vault:admin", label: "vault:admin — full access (use sparingly)" },
+];
+
+export function scopeGrants(scope: VaultScope): {
+  summary: string;
+  granted: readonly string[];
+  withheld: readonly string[];
+  adminNote?: string;
+} {
+  if (scope === "vault:read") {
+    return {
+      summary: "Read-only access. The agent can query the vault but cannot create, modify, or delete anything.",
+      granted: READ_TOOLS,
+      withheld: WRITE_TOOLS,
+    };
+  }
+  if (scope === "vault:write") {
+    return {
+      summary: "Read + write. The agent can capture and update notes and tags, but cannot manage vault config or tokens.",
+      granted: [...READ_TOOLS, ...WRITE_TOOLS],
+      withheld: [],
+    };
+  }
+  return {
+    summary: "Full access including vault config (/.parachute/config*) and token management. Use sparingly.",
+    granted: [...READ_TOOLS, ...WRITE_TOOLS],
+    withheld: [],
+    adminNote: "Admin tokens can read and write any path including vault config — only grant when the agent genuinely needs it.",
+  };
+}
+
+export function ScopeGrants({ scope }: { scope: VaultScope }) {
+  const grants = scopeGrants(scope);
+  return (
+    <div className="scope-grants">
+      <p className="scope-grants-summary">{grants.summary}</p>
+      <div className="scope-grants-tools">
+        <div>
+          <span className="scope-grants-label">Allows</span>
+          <ul>
+            {grants.granted.map((t) => (
+              <li key={t}>
+                <code>{t}</code>
+              </li>
+            ))}
+          </ul>
+        </div>
+        {grants.withheld.length > 0 && (
+          <div>
+            <span className="scope-grants-label">Blocks</span>
+            <ul>
+              {grants.withheld.map((t) => (
+                <li key={t} className="dim">
+                  <code>{t}</code>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+      {grants.adminNote && (
+        <p className="scope-grants-warn">{grants.adminNote}</p>
+      )}
+    </div>
+  );
+}

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -90,3 +90,46 @@ export async function detachVault(folder: string, mcpName?: string): Promise<Age
   );
   return r.group;
 }
+
+export interface FolderAvailability {
+  slug: string;
+  valid: boolean;
+  available: boolean;
+  reason?: string;
+}
+
+export async function checkFolderAvailability(slug: string): Promise<FolderAvailability> {
+  return request<FolderAvailability>(
+    `/folder-availability/${encodeURIComponent(slug)}`,
+  );
+}
+
+export async function fetchFolderSuggestion(name: string): Promise<string> {
+  const r = await request<{ name: string; slug: string }>(
+    `/folder-suggestion?name=${encodeURIComponent(name)}`,
+  );
+  return r.slug;
+}
+
+export interface CreateGroupInput {
+  name: string;
+  folder: string;
+  instructions?: string;
+  vault?: {
+    scope: VaultScope;
+    vaultBaseUrl?: string;
+    tokenLabel?: string;
+    token?: string;
+    mcpName?: string;
+  };
+}
+
+export async function createGroup(input: CreateGroupInput): Promise<{
+  group: AgentGroupView;
+  mintedVaultToken: boolean;
+}> {
+  return request<{ group: AgentGroupView; mintedVaultToken: boolean }>(
+    `/groups`,
+    { method: "POST", json: input },
+  );
+}

--- a/web/ui/src/routes/GroupDetail.tsx
+++ b/web/ui/src/routes/GroupDetail.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
+import { ScopeGrants, SCOPE_OPTIONS } from "../components/ScopeGrants.tsx";
 import {
   attachVault,
   detachVault,
@@ -7,43 +8,6 @@ import {
   type AgentGroupView,
   type VaultScope,
 } from "../lib/api.ts";
-
-const SCOPE_OPTIONS: { value: VaultScope; label: string }[] = [
-  { value: "vault:read", label: "vault:read — query, can't modify" },
-  { value: "vault:write", label: "vault:write — capture and update notes" },
-  { value: "vault:admin", label: "vault:admin — full access (use sparingly)" },
-];
-
-const READ_TOOLS = ["query-notes", "list-tags", "find-path", "vault-info"] as const;
-const WRITE_TOOLS = ["create-note", "update-note", "delete-note", "update-tag", "delete-tag"] as const;
-
-function scopeGrants(scope: VaultScope): {
-  summary: string;
-  granted: readonly string[];
-  withheld: readonly string[];
-  adminNote?: string;
-} {
-  if (scope === "vault:read") {
-    return {
-      summary: "Read-only access. The agent can query the vault but cannot create, modify, or delete anything.",
-      granted: READ_TOOLS,
-      withheld: WRITE_TOOLS,
-    };
-  }
-  if (scope === "vault:write") {
-    return {
-      summary: "Read + write. The agent can capture and update notes and tags, but cannot manage vault config or tokens.",
-      granted: [...READ_TOOLS, ...WRITE_TOOLS],
-      withheld: [],
-    };
-  }
-  return {
-    summary: "Full access including vault config (/.parachute/config*) and token management. Use sparingly.",
-    granted: [...READ_TOOLS, ...WRITE_TOOLS],
-    withheld: [],
-    adminNote: "Admin tokens can read and write any path including vault config — only grant when the agent genuinely needs it.",
-  };
-}
 
 export function GroupDetail() {
   const { folder } = useParams<{ folder: string }>();
@@ -328,38 +292,3 @@ export function GroupDetail() {
   );
 }
 
-function ScopeGrants({ scope }: { scope: VaultScope }) {
-  const grants = scopeGrants(scope);
-  return (
-    <div className="scope-grants">
-      <p className="scope-grants-summary">{grants.summary}</p>
-      <div className="scope-grants-tools">
-        <div>
-          <span className="scope-grants-label">Allows</span>
-          <ul>
-            {grants.granted.map((t) => (
-              <li key={t}>
-                <code>{t}</code>
-              </li>
-            ))}
-          </ul>
-        </div>
-        {grants.withheld.length > 0 && (
-          <div>
-            <span className="scope-grants-label">Blocks</span>
-            <ul>
-              {grants.withheld.map((t) => (
-                <li key={t} className="dim">
-                  <code>{t}</code>
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
-      </div>
-      {grants.adminNote && (
-        <p className="scope-grants-warn">{grants.adminNote}</p>
-      )}
-    </div>
-  );
-}

--- a/web/ui/src/routes/GroupList.tsx
+++ b/web/ui/src/routes/GroupList.tsx
@@ -73,22 +73,17 @@ export function GroupList() {
         <div className="empty empty-rich">
           <p className="empty-headline">No agent groups yet.</p>
           <p className="muted">
-            Paraclaw will spin up agent groups from here soon
-            {" "}
-            (
-            <a
-              href="https://github.com/ParachuteComputer/paraclaw/issues/1"
-              target="_blank"
-              rel="noreferrer"
-            >
-              #1: new-agent wizard
-            </a>
-            ). Until then, bootstrap your first group via:
+            Spin up your first agent group in a few clicks — or bootstrap from
+            the CLI if you prefer.
           </p>
           <ul className="empty-paths">
             <li>
+              <strong>New agent wizard</strong> —
+              name + folder + optional vault attach.
+            </li>
+            <li>
               <strong>Claude Code skill</strong> —
-              run <code>/init-first-agent</code> to walk through channel pick + identity + welcome DM.
+              run <code>/init-first-agent</code> for channel pick + identity + welcome DM.
             </li>
             <li>
               <strong>CLI setup</strong> —
@@ -96,6 +91,7 @@ export function GroupList() {
             </li>
           </ul>
           <div className="actions" style={{ justifyContent: "center", marginTop: "1rem" }}>
+            <Link to="/groups/new"><button>+ New agent group</button></Link>
             <button className="secondary" onClick={reload}>Refresh</button>
           </div>
         </div>
@@ -105,7 +101,10 @@ export function GroupList() {
 
   return (
     <div>
-      <h2>Agent groups ({state.groups.length})</h2>
+      <div className="list-header">
+        <h2>Agent groups ({state.groups.length})</h2>
+        <Link to="/groups/new"><button>+ New agent group</button></Link>
+      </div>
       {state.groups.map((g) => (
         <Link
           key={g.id}

--- a/web/ui/src/routes/NewGroupWizard.tsx
+++ b/web/ui/src/routes/NewGroupWizard.tsx
@@ -1,0 +1,375 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { ScopeGrants, SCOPE_OPTIONS } from "../components/ScopeGrants.tsx";
+import {
+  checkFolderAvailability,
+  createGroup,
+  fetchFolderSuggestion,
+  type FolderAvailability,
+  type VaultScope,
+} from "../lib/api.ts";
+
+type Step = "identity" | "vault" | "confirm";
+
+const DEFAULT_VAULT_URL = "http://127.0.0.1:1940/vault/default";
+
+export function NewGroupWizard() {
+  const navigate = useNavigate();
+  const [step, setStep] = useState<Step>("identity");
+
+  // Identity.
+  const [name, setName] = useState("");
+  const [folder, setFolder] = useState("");
+  const [folderTouched, setFolderTouched] = useState(false);
+  const [instructions, setInstructions] = useState("");
+  const [folderCheck, setFolderCheck] = useState<FolderAvailability | null>(null);
+  const [folderChecking, setFolderChecking] = useState(false);
+
+  // Vault.
+  const [attachVault, setAttachVault] = useState(false);
+  const [scope, setScope] = useState<VaultScope>("vault:read");
+  const [vaultBaseUrl, setVaultBaseUrl] = useState(DEFAULT_VAULT_URL);
+  const [pasteToken, setPasteToken] = useState("");
+  const [tokenLabel, setTokenLabel] = useState("");
+
+  // Submit.
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Suggest a folder slug from the name when the user hasn't typed one.
+  useEffect(() => {
+    if (folderTouched) return;
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setFolder("");
+      return;
+    }
+    let cancelled = false;
+    fetchFolderSuggestion(trimmed)
+      .then((slug) => {
+        if (!cancelled && !folderTouched) setFolder(slug);
+      })
+      .catch(() => {
+        // Suggestion failure is non-fatal; user can type their own.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [name, folderTouched]);
+
+  // Debounce folder availability check.
+  const folderCheckTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (!folder) {
+      setFolderCheck(null);
+      return;
+    }
+    if (folderCheckTimer.current) clearTimeout(folderCheckTimer.current);
+    setFolderChecking(true);
+    folderCheckTimer.current = setTimeout(async () => {
+      try {
+        const result = await checkFolderAvailability(folder);
+        setFolderCheck(result);
+      } catch (err) {
+        setFolderCheck({
+          slug: folder,
+          valid: false,
+          available: false,
+          reason: err instanceof Error ? err.message : String(err),
+        });
+      } finally {
+        setFolderChecking(false);
+      }
+    }, 250);
+    return () => {
+      if (folderCheckTimer.current) clearTimeout(folderCheckTimer.current);
+    };
+  }, [folder]);
+
+  const identityReady =
+    name.trim().length > 0 &&
+    folder.length > 0 &&
+    folderCheck?.valid === true &&
+    folderCheck?.available === true;
+
+  const onFolderChange = useCallback((next: string) => {
+    setFolderTouched(true);
+    setFolder(next);
+  }, []);
+
+  const onCreate = async () => {
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      const result = await createGroup({
+        name: name.trim(),
+        folder,
+        instructions: instructions.trim() || undefined,
+        vault: attachVault
+          ? {
+              scope,
+              vaultBaseUrl: vaultBaseUrl.trim().replace(/\/+$/, "") || DEFAULT_VAULT_URL,
+              tokenLabel: tokenLabel.trim() || undefined,
+              token: pasteToken.trim() || undefined,
+            }
+          : undefined,
+      });
+      navigate(`/groups/${encodeURIComponent(result.group.folder)}`);
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div>
+      <Link to="/" className="muted">← All groups</Link>
+      <h2 style={{ marginTop: "0.5rem" }}>New agent group</h2>
+      <WizardSteps current={step} />
+
+      {step === "identity" && (
+        <div className="section">
+          <h3>Identity</h3>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (identityReady) setStep("vault");
+            }}
+          >
+            <div className="row">
+              <label htmlFor="name">Name</label>
+              <input
+                id="name"
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. Forge"
+                autoFocus
+              />
+              <p className="dim">
+                The display name. Folder slug is derived from this — you can override below.
+              </p>
+            </div>
+
+            <div className="row">
+              <label htmlFor="folder">Folder slug</label>
+              <input
+                id="folder"
+                type="text"
+                value={folder}
+                onChange={(e) => onFolderChange(e.target.value)}
+                placeholder="e.g. forge"
+              />
+              <FolderHint folder={folder} checking={folderChecking} check={folderCheck} />
+            </div>
+
+            <div className="row">
+              <label htmlFor="instructions">Instructions (optional)</label>
+              <textarea
+                id="instructions"
+                value={instructions}
+                onChange={(e) => setInstructions(e.target.value)}
+                placeholder="Goes into CLAUDE.local.md. Leave blank for the default."
+              />
+              <p className="dim">
+                What the agent should know about itself. Empty = the standard scaffold.
+              </p>
+            </div>
+
+            <div className="actions">
+              <button type="submit" disabled={!identityReady}>Next: vault</button>
+              <Link to="/" className="muted" style={{ marginLeft: "0.5rem" }}>Cancel</Link>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {step === "vault" && (
+        <div className="section">
+          <h3>Vault attachment</h3>
+          <p className="muted">
+            Attach the parachute vault now, or skip and attach later from the group's detail page.
+          </p>
+
+          <div className="row" style={{ marginTop: "0.5rem" }}>
+            <label className="wizard-toggle">
+              <input
+                type="checkbox"
+                checked={attachVault}
+                onChange={(e) => setAttachVault(e.target.checked)}
+              />
+              <span>Attach vault now</span>
+            </label>
+          </div>
+
+          {attachVault && (
+            <>
+              <div className="row">
+                <label htmlFor="vaultBaseUrl">Vault URL</label>
+                <input
+                  id="vaultBaseUrl"
+                  type="text"
+                  value={vaultBaseUrl}
+                  onChange={(e) => setVaultBaseUrl(e.target.value)}
+                />
+                <p className="dim">
+                  Default is the local vault at <code>{DEFAULT_VAULT_URL}</code>.
+                </p>
+              </div>
+
+              <div className="row">
+                <label htmlFor="scope">Scope</label>
+                <select
+                  id="scope"
+                  value={scope}
+                  onChange={(e) => setScope(e.target.value as VaultScope)}
+                >
+                  {SCOPE_OPTIONS.map((s) => (
+                    <option key={s.value} value={s.value}>
+                      {s.label}
+                    </option>
+                  ))}
+                </select>
+                <ScopeGrants scope={scope} />
+              </div>
+
+              <div className="row">
+                <label htmlFor="tokenLabel">Token label</label>
+                <input
+                  id="tokenLabel"
+                  type="text"
+                  value={tokenLabel}
+                  onChange={(e) => setTokenLabel(e.target.value)}
+                  placeholder={`claw-${folder || "<folder>"}`}
+                />
+                <p className="dim">
+                  Used for revocation. Default: <code>claw-{folder || "<folder>"}</code>.
+                </p>
+              </div>
+
+              <div className="row">
+                <label htmlFor="pasteToken">Paste an existing token (optional)</label>
+                <input
+                  id="pasteToken"
+                  type="text"
+                  value={pasteToken}
+                  onChange={(e) => setPasteToken(e.target.value)}
+                  placeholder="pvt_…  (leave blank to mint via the parachute CLI)"
+                />
+                <p className="dim">
+                  When blank, the server runs <code>parachute vault tokens create</code> for you.
+                </p>
+              </div>
+            </>
+          )}
+
+          <div className="actions" style={{ marginTop: "1rem" }}>
+            <button className="secondary" onClick={() => setStep("identity")}>Back</button>
+            <button onClick={() => setStep("confirm")}>Next: confirm</button>
+          </div>
+        </div>
+      )}
+
+      {step === "confirm" && (
+        <div className="section">
+          <h3>Confirm</h3>
+          <div className="kv">
+            <div>name</div><div>{name}</div>
+            <div>folder</div><div><code>{folder}</code></div>
+            <div>instructions</div>
+            <div>{instructions.trim() ? <em>(custom)</em> : <span className="dim">default</span>}</div>
+            <div>vault</div>
+            <div>
+              {attachVault ? (
+                <>
+                  <span className="tag">{scope}</span>{" "}
+                  <code>{vaultBaseUrl.trim().replace(/\/+$/, "") || DEFAULT_VAULT_URL}</code>
+                </>
+              ) : (
+                <span className="dim">skip — attach later</span>
+              )}
+            </div>
+            {attachVault && (
+              <>
+                <div>token label</div>
+                <div><code>{tokenLabel.trim() || `claw-${folder}`}</code></div>
+                <div>token</div>
+                <div>
+                  {pasteToken.trim()
+                    ? <span className="dim">using pasted token</span>
+                    : <span className="dim">server will mint a fresh token</span>}
+                </div>
+              </>
+            )}
+          </div>
+
+          {submitError && (
+            <div className="error-banner" style={{ marginTop: "1rem" }}>{submitError}</div>
+          )}
+
+          <div className="actions" style={{ marginTop: "1rem" }}>
+            <button className="secondary" onClick={() => setStep("vault")} disabled={submitting}>
+              Back
+            </button>
+            <button onClick={onCreate} disabled={submitting}>
+              {submitting ? "Creating…" : "Create agent group"}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FolderHint({
+  folder,
+  checking,
+  check,
+}: {
+  folder: string;
+  checking: boolean;
+  check: FolderAvailability | null;
+}) {
+  if (!folder) {
+    return (
+      <p className="dim">
+        Lowercase letters, digits, and dashes; ≤ 48 chars. Becomes <code>groups/&lt;slug&gt;/</code>.
+      </p>
+    );
+  }
+  if (checking || !check) {
+    return <p className="dim">Checking <code>{folder}</code>…</p>;
+  }
+  if (!check.valid) {
+    return <p className="wizard-folder-error">{check.reason ?? "Invalid slug."}</p>;
+  }
+  if (!check.available) {
+    return <p className="wizard-folder-error">{check.reason ?? "Already taken."}</p>;
+  }
+  return (
+    <p className="wizard-folder-ok">
+      <code>groups/{folder}/</code> is available.
+    </p>
+  );
+}
+
+function WizardSteps({ current }: { current: Step }) {
+  const steps: { key: Step; label: string }[] = [
+    { key: "identity", label: "1. Identity" },
+    { key: "vault", label: "2. Vault" },
+    { key: "confirm", label: "3. Confirm" },
+  ];
+  return (
+    <ol className="wizard-steps">
+      {steps.map((s) => (
+        <li
+          key={s.key}
+          className={`wizard-step${s.key === current ? " active" : ""}`}
+        >
+          {s.label}
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -297,3 +297,62 @@ hr.sep { border: 0; border-top: 1px solid var(--border); margin: 1.5rem 0; }
   font-size: 0.82rem;
   color: var(--warn);
 }
+
+/* List header (with CTA on the right) */
+.list-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+.list-header h2 { margin: 0; }
+
+/* Wizard step indicator */
+.wizard-steps {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1.25rem;
+  display: flex;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+}
+.wizard-step {
+  padding: 0.4rem 0.8rem;
+  background: var(--bg-soft);
+  color: var(--fg-muted);
+  border-radius: 999px;
+  border: 1px solid var(--border);
+}
+.wizard-step.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-color: var(--accent);
+  font-weight: 500;
+}
+
+/* Wizard form bits */
+.wizard-toggle {
+  display: inline-flex !important;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  color: var(--fg) !important;
+  font-size: 0.95rem !important;
+  font-weight: 400 !important;
+  margin: 0 !important;
+}
+.wizard-toggle input[type="checkbox"] {
+  width: auto;
+  margin: 0;
+}
+.wizard-folder-ok {
+  margin: 0.4rem 0 0;
+  font-size: 0.85rem;
+  color: var(--accent);
+}
+.wizard-folder-error {
+  margin: 0.4rem 0 0;
+  font-size: 0.85rem;
+  color: var(--error);
+}


### PR DESCRIPTION
## Summary

Closes #1. Paraclaw can now create agent groups from the web UI without Claude Code — the load-bearing piece for "work easily end-to-end".

- **`src/parachute/create-agent.ts`** — integration shim: `validateFolderSlug`, `suggestFolderSlug`, `isFolderTaken`, `createParachuteAgentGroup({ name, folder, instructions?, vault? })`. Wraps NanoClaw's central-DB write + on-disk init (`initGroupFilesystem`) + optional inline `attachVaultToGroup`. **No upstream NanoClaw files modified.** Channel wiring intentionally out of scope (issue #2).
- **`web/server`** — `POST /api/groups`, `GET /api/folder-availability/:slug`, `GET /api/folder-suggestion?name=...`. Server now `initDb()` + `runMigrations()` at boot so the shared DB connection covers writes.
- **`web/ui`** — new `NewGroupWizard` route: 3-step form Identity → Vault → Confirm. Reuses the existing scope-picker via a shared `components/ScopeGrants.tsx` (extracted from `GroupDetail`). "+ New agent group" CTAs added to the empty state and list header.
- Versions bumped `0.0.2-rc.1 → 0.0.3-rc.1` for both server + UI.

Provider selection is omitted from wizard v1 (claude default only) — the "other provider" surface lands once channel wiring is on the table. The wizard creates a channel-less group; channel install stays its own issue (#2).

## Architectural shift to flag

**The web server now holds a writable DB connection.** Until this PR the server only did per-call readonly reads; with the wizard it goes through the same `initDb` + `runMigrations` path NanoClaw uses everywhere else (preserving migration discipline rather than rolling our own). better-sqlite3 in WAL mode supports multiple writers, and the server still avoids long write transactions, but this is the first place where a non-NanoClaw process writes to `data/v2.db`. Worth a deliberate look.

DB → FS order matches `init-first-agent.ts` precedent (no rollback machinery). The optimistic-concurrency pattern doesn't apply here (no `if_updated_at` on inserts) but will when an "edit group" surface lands later.

## Test plan

- [x] `cd web/ui && pnpm typecheck` — clean
- [x] `cd web/ui && pnpm build` — clean
- [x] `cd web/server && pnpm typecheck` — clean
- [x] `pnpm typecheck` at repo root — clean
- [ ] Smoke: `pnpm dev` (web/server + web/ui), open `/groups/new`, create a group with no vault → group shows in list, detail page renders
- [ ] Smoke: create another with `vault:read` (mint flow) → vault attached, detail shows scope tag + scope-grants explainer
- [ ] Smoke: folder-availability hint shows red for already-taken slugs, green for unused slugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)