### PR TITLE
feat(web): live agent-group status (closes #5)

### DIFF
--- a/src/parachute/group-status.test.ts
+++ b/src/parachute/group-status.test.ts
@@ -81,9 +81,7 @@ function seedInboundDb(sessionId: string, lastTimestamp: string) {
   const dbPath = inboundDbPath('ag-1', sessionId);
   const db = new Database(dbPath);
   db.exec(INBOUND_SCHEMA);
-  db.prepare(
-    "INSERT INTO messages_in (id, kind, timestamp, content) VALUES ('m1', 'msg', ?, '{}')",
-  ).run(lastTimestamp);
+  db.prepare("INSERT INTO messages_in (id, kind, timestamp, content) VALUES ('m1', 'msg', ?, '{}')").run(lastTimestamp);
   db.close();
 }
 
@@ -91,9 +89,9 @@ function seedOutboundDb(sessionId: string, lastTimestamp: string) {
   const dbPath = outboundDbPath('ag-1', sessionId);
   const db = new Database(dbPath);
   db.exec(OUTBOUND_SCHEMA);
-  db.prepare(
-    "INSERT INTO messages_out (id, kind, timestamp, content) VALUES ('o1', 'msg', ?, '{}')",
-  ).run(lastTimestamp);
+  db.prepare("INSERT INTO messages_out (id, kind, timestamp, content) VALUES ('o1', 'msg', ?, '{}')").run(
+    lastTimestamp,
+  );
   db.close();
 }
 

--- a/src/parachute/group-status.test.ts
+++ b/src/parachute/group-status.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for getGroupStatus — the helper the web server uses to compute
+ * "is this agent group's container alive?" without depending on
+ * container-runner.ts's in-memory map (different process from web server).
+ */
+import Database from 'better-sqlite3';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../config.js', async () => {
+  const actual = await vi.importActual('../config.js');
+  return { ...actual, DATA_DIR: '/tmp/paraclaw-group-status-test' };
+});
+
+const TEST_DIR = '/tmp/paraclaw-group-status-test';
+
+let initTestDb: typeof import('../db/index.js').initTestDb;
+let closeDb: typeof import('../db/index.js').closeDb;
+let runMigrations: typeof import('../db/index.js').runMigrations;
+let createAgentGroup: typeof import('../db/index.js').createAgentGroup;
+let createSession: typeof import('../db/sessions.js').createSession;
+let getGroupStatus: typeof import('./group-status.js').getGroupStatus;
+let inboundDbPath: typeof import('../session-manager.js').inboundDbPath;
+let outboundDbPath: typeof import('../session-manager.js').outboundDbPath;
+let heartbeatPath: typeof import('../session-manager.js').heartbeatPath;
+let INBOUND_SCHEMA: string;
+let OUTBOUND_SCHEMA: string;
+
+beforeEach(async () => {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+
+  // Imported lazily so the config.js mock is in effect when modules cache it.
+  ({ initTestDb, closeDb, runMigrations, createAgentGroup } = await import('../db/index.js'));
+  ({ createSession } = await import('../db/sessions.js'));
+  ({ getGroupStatus } = await import('./group-status.js'));
+  ({ inboundDbPath, outboundDbPath, heartbeatPath } = await import('../session-manager.js'));
+  ({ INBOUND_SCHEMA, OUTBOUND_SCHEMA } = await import('../db/schema.js'));
+
+  const db = initTestDb();
+  runMigrations(db);
+
+  createAgentGroup({
+    id: 'ag-1',
+    name: 'Forge',
+    folder: 'forge',
+    agent_provider: null,
+    created_at: '2026-04-27T00:00:00.000Z',
+  });
+});
+
+afterEach(() => {
+  closeDb();
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+});
+
+function makeSession(id: string) {
+  createSession({
+    id,
+    agent_group_id: 'ag-1',
+    messaging_group_id: null,
+    thread_id: null,
+    agent_provider: null,
+    status: 'active',
+    container_status: 'running',
+    last_active: '2026-04-27T00:00:00.000Z',
+    created_at: '2026-04-27T00:00:00.000Z',
+  });
+  fs.mkdirSync(path.dirname(heartbeatPath('ag-1', id)), { recursive: true });
+}
+
+function writeHeartbeat(sessionId: string, mtimeMs: number) {
+  const p = heartbeatPath('ag-1', sessionId);
+  fs.writeFileSync(p, '');
+  fs.utimesSync(p, mtimeMs / 1000, mtimeMs / 1000);
+}
+
+function seedInboundDb(sessionId: string, lastTimestamp: string) {
+  const dbPath = inboundDbPath('ag-1', sessionId);
+  const db = new Database(dbPath);
+  db.exec(INBOUND_SCHEMA);
+  db.prepare(
+    "INSERT INTO messages_in (id, kind, timestamp, content) VALUES ('m1', 'msg', ?, '{}')",
+  ).run(lastTimestamp);
+  db.close();
+}
+
+function seedOutboundDb(sessionId: string, lastTimestamp: string) {
+  const dbPath = outboundDbPath('ag-1', sessionId);
+  const db = new Database(dbPath);
+  db.exec(OUTBOUND_SCHEMA);
+  db.prepare(
+    "INSERT INTO messages_out (id, kind, timestamp, content) VALUES ('o1', 'msg', ?, '{}')",
+  ).run(lastTimestamp);
+  db.close();
+}
+
+describe('getGroupStatus', () => {
+  it('returns null for unknown folder', () => {
+    expect(getGroupStatus('does-not-exist')).toBeNull();
+  });
+
+  it('returns empty status for a group with no sessions', () => {
+    const status = getGroupStatus('forge');
+    expect(status).not.toBeNull();
+    expect(status!.containerRunning).toBe(false);
+    expect(status!.activeSessionCount).toBe(0);
+    expect(status!.sessionCount).toBe(0);
+    expect(status!.sessions).toEqual([]);
+  });
+
+  it('marks a session alive when its heartbeat is fresh', () => {
+    const now = Date.parse('2026-04-27T12:00:00.000Z');
+    makeSession('s-fresh');
+    writeHeartbeat('s-fresh', now - 30_000); // 30s ago — well under 90s threshold
+
+    const status = getGroupStatus('forge', { nowMs: now });
+    expect(status!.containerRunning).toBe(true);
+    expect(status!.activeSessionCount).toBe(1);
+    expect(status!.sessions[0].alive).toBe(true);
+    expect(status!.sessions[0].lastHeartbeatAt).toBe(new Date(now - 30_000).toISOString());
+  });
+
+  it('marks a session dead when heartbeat is older than the threshold', () => {
+    const now = Date.parse('2026-04-27T12:00:00.000Z');
+    makeSession('s-stale');
+    writeHeartbeat('s-stale', now - 120_000); // 2 min ago
+
+    const status = getGroupStatus('forge', { nowMs: now });
+    expect(status!.containerRunning).toBe(false);
+    expect(status!.activeSessionCount).toBe(0);
+    expect(status!.sessions[0].alive).toBe(false);
+  });
+
+  it('aggregates last-message timestamps across sessions', () => {
+    const now = Date.parse('2026-04-27T12:00:00.000Z');
+
+    makeSession('s-a');
+    writeHeartbeat('s-a', now - 5_000);
+    seedInboundDb('s-a', '2026-04-27T11:55:00.000Z');
+    seedOutboundDb('s-a', '2026-04-27T11:56:00.000Z');
+
+    makeSession('s-b');
+    writeHeartbeat('s-b', now - 10_000);
+    seedInboundDb('s-b', '2026-04-27T11:58:00.000Z'); // newer
+    seedOutboundDb('s-b', '2026-04-27T11:50:00.000Z'); // older
+
+    const status = getGroupStatus('forge', { nowMs: now });
+    expect(status!.activeSessionCount).toBe(2);
+    expect(status!.lastMessageInAt).toBe('2026-04-27T11:58:00.000Z');
+    expect(status!.lastMessageOutAt).toBe('2026-04-27T11:56:00.000Z');
+  });
+
+  it('tolerates missing session dirs and DBs', () => {
+    const now = Date.parse('2026-04-27T12:00:00.000Z');
+    // Session row exists but no heartbeat / DB files have been created yet.
+    makeSession('s-empty');
+
+    const status = getGroupStatus('forge', { nowMs: now });
+    expect(status!.containerRunning).toBe(false);
+    expect(status!.sessions[0].alive).toBe(false);
+    expect(status!.sessions[0].lastMessageInAt).toBeNull();
+    expect(status!.sessions[0].lastMessageOutAt).toBeNull();
+  });
+});

--- a/src/parachute/group-status.ts
+++ b/src/parachute/group-status.ts
@@ -76,7 +76,13 @@ export function getGroupStatus(folder: string, opts: GroupStatusOpts = {}): Grou
 
 function readSessionStatus(
   agentGroupId: string,
-  session: { id: string; status: 'active' | 'closed'; container_status: 'running' | 'idle' | 'stopped'; created_at: string; last_active: string | null },
+  session: {
+    id: string;
+    status: 'active' | 'closed';
+    container_status: 'running' | 'idle' | 'stopped';
+    created_at: string;
+    last_active: string | null;
+  },
   nowMs: number,
   aliveThresholdMs: number,
 ): SessionStatus {
@@ -109,9 +115,7 @@ function maxTimestamp(dbPath: string, table: 'messages_in' | 'messages_out'): st
   let db: Database.Database | null = null;
   try {
     db = new Database(dbPath, { readonly: true, fileMustExist: true });
-    const row = db.prepare(`SELECT MAX(timestamp) AS ts FROM ${table}`).get() as
-      | { ts: string | null }
-      | undefined;
+    const row = db.prepare(`SELECT MAX(timestamp) AS ts FROM ${table}`).get() as { ts: string | null } | undefined;
     return row?.ts ?? null;
   } catch {
     // Session DB not initialized yet, schema mismatch, or transient lock — caller treats null as "no data".

--- a/src/parachute/group-status.ts
+++ b/src/parachute/group-status.ts
@@ -1,0 +1,131 @@
+/**
+ * Live status for an agent group: whether its container is alive right now,
+ * how many sessions are active, and last-message timestamps from the per-
+ * session DBs.
+ *
+ * The web server polls this so the UI can show "which agents are alive."
+ * NanoClaw's `isContainerRunning(sessionId)` (in-memory map in
+ * container-runner.ts) is host-process scoped — useless from the web server.
+ * Heartbeat file mtime is the only cross-process liveness signal:
+ *
+ *   data/v2-sessions/<agent_group_id>/<session_id>/.heartbeat
+ *
+ * The container's agent-runner touches this on every poll iteration.
+ * NanoClaw's host sweep runs at 60s intervals; we use 90s as the "alive"
+ * threshold so the dot doesn't blink during a sweep tick.
+ */
+import Database from 'better-sqlite3';
+import fs from 'node:fs';
+
+import { getAgentGroupByFolder } from '../db/agent-groups.js';
+import { getSessionsByAgentGroup } from '../db/sessions.js';
+import { heartbeatPath, inboundDbPath, outboundDbPath } from '../session-manager.js';
+
+export const DEFAULT_ALIVE_THRESHOLD_MS = 90_000;
+
+export interface SessionStatus {
+  sessionId: string;
+  status: 'active' | 'closed';
+  containerStatus: 'running' | 'idle' | 'stopped';
+  alive: boolean;
+  lastHeartbeatAt: string | null;
+  lastMessageInAt: string | null;
+  lastMessageOutAt: string | null;
+  createdAt: string;
+  lastActiveAt: string | null;
+}
+
+export interface GroupStatus {
+  containerRunning: boolean;
+  activeSessionCount: number;
+  sessionCount: number;
+  lastHeartbeatAt: string | null;
+  lastMessageInAt: string | null;
+  lastMessageOutAt: string | null;
+  sessions: SessionStatus[];
+}
+
+export interface GroupStatusOpts {
+  /** Override the alive threshold (mainly for tests). */
+  aliveThresholdMs?: number;
+  /** Inject "now" for deterministic tests. */
+  nowMs?: number;
+}
+
+export function getGroupStatus(folder: string, opts: GroupStatusOpts = {}): GroupStatus | null {
+  const group = getAgentGroupByFolder(folder);
+  if (!group) return null;
+
+  const aliveThresholdMs = opts.aliveThresholdMs ?? DEFAULT_ALIVE_THRESHOLD_MS;
+  const nowMs = opts.nowMs ?? Date.now();
+
+  const sessions = getSessionsByAgentGroup(group.id).map((s) =>
+    readSessionStatus(group.id, s, nowMs, aliveThresholdMs),
+  );
+
+  return {
+    containerRunning: sessions.some((s) => s.alive),
+    activeSessionCount: sessions.filter((s) => s.alive).length,
+    sessionCount: sessions.filter((s) => s.status === 'active').length,
+    lastHeartbeatAt: latest(sessions.map((s) => s.lastHeartbeatAt)),
+    lastMessageInAt: latest(sessions.map((s) => s.lastMessageInAt)),
+    lastMessageOutAt: latest(sessions.map((s) => s.lastMessageOutAt)),
+    sessions,
+  };
+}
+
+function readSessionStatus(
+  agentGroupId: string,
+  session: { id: string; status: 'active' | 'closed'; container_status: 'running' | 'idle' | 'stopped'; created_at: string; last_active: string | null },
+  nowMs: number,
+  aliveThresholdMs: number,
+): SessionStatus {
+  const heartbeatMs = readHeartbeatMtimeMs(agentGroupId, session.id);
+  const alive = heartbeatMs > 0 && nowMs - heartbeatMs <= aliveThresholdMs;
+
+  return {
+    sessionId: session.id,
+    status: session.status,
+    containerStatus: session.container_status,
+    alive,
+    lastHeartbeatAt: heartbeatMs > 0 ? new Date(heartbeatMs).toISOString() : null,
+    lastMessageInAt: maxTimestamp(inboundDbPath(agentGroupId, session.id), 'messages_in'),
+    lastMessageOutAt: maxTimestamp(outboundDbPath(agentGroupId, session.id), 'messages_out'),
+    createdAt: session.created_at,
+    lastActiveAt: session.last_active,
+  };
+}
+
+function readHeartbeatMtimeMs(agentGroupId: string, sessionId: string): number {
+  try {
+    return fs.statSync(heartbeatPath(agentGroupId, sessionId)).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+function maxTimestamp(dbPath: string, table: 'messages_in' | 'messages_out'): string | null {
+  if (!fs.existsSync(dbPath)) return null;
+  let db: Database.Database | null = null;
+  try {
+    db = new Database(dbPath, { readonly: true, fileMustExist: true });
+    const row = db.prepare(`SELECT MAX(timestamp) AS ts FROM ${table}`).get() as
+      | { ts: string | null }
+      | undefined;
+    return row?.ts ?? null;
+  } catch {
+    // Session DB not initialized yet, schema mismatch, or transient lock — caller treats null as "no data".
+    return null;
+  } finally {
+    db?.close();
+  }
+}
+
+function latest(values: (string | null)[]): string | null {
+  let best: string | null = null;
+  for (const v of values) {
+    if (!v) continue;
+    if (!best || v > best) best = v;
+  }
+  return best;
+}

--- a/web/server/package.json
+++ b/web/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraclaw/web-server",
-  "version": "0.0.3-rc.1",
+  "version": "0.0.4-rc.1",
   "private": true,
   "description": "Paraclaw web UI server. Lists agent groups + manages vault attachments. Reuses NanoClaw's better-sqlite3 + Parachute attach helpers.",
   "license": "AGPL-3.0",

--- a/web/server/src/server.ts
+++ b/web/server/src/server.ts
@@ -42,6 +42,7 @@ import {
   suggestFolderSlug,
   validateFolderSlug,
 } from '../../../src/parachute/create-agent.js';
+import { getGroupStatus, type GroupStatus } from '../../../src/parachute/group-status.js';
 
 const CENTRAL_DB_PATH = path.join(DATA_DIR, 'v2.db');
 
@@ -68,6 +69,7 @@ interface AgentGroupRow {
 
 interface AgentGroupView extends AgentGroupRow {
   vault: ReturnType<typeof readVaultAttachment>;
+  status: GroupStatus | null;
 }
 
 function getDb(): Database.Database {
@@ -90,6 +92,7 @@ function listAgentGroups(): AgentGroupView[] {
     return rows.map((r) => ({
       ...r,
       vault: readVaultAttachment(r.folder),
+      status: getGroupStatus(r.folder),
     }));
   } finally {
     db.close();
@@ -105,7 +108,11 @@ function getAgentGroup(folder: string): AgentGroupView | null {
       )
       .get(folder) as AgentGroupRow | undefined;
     if (!row) return null;
-    return { ...row, vault: readVaultAttachment(row.folder) };
+    return {
+      ...row,
+      vault: readVaultAttachment(row.folder),
+      status: getGroupStatus(row.folder),
+    };
   } finally {
     db.close();
   }
@@ -190,7 +197,7 @@ async function handleApi(
   if (pathname === '/api/health' && method === 'GET') {
     json(res, 200, {
       service: 'paraclaw-web-server',
-      version: '0.0.3-rc.1',
+      version: '0.0.4-rc.1',
       data_dir: DATA_DIR,
       groups_dir: GROUPS_DIR,
     });

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraclaw/web-ui",
-  "version": "0.0.3-rc.1",
+  "version": "0.0.4-rc.1",
   "private": true,
   "description": "Paraclaw web UI — Vite + React + TypeScript. Manages vault attachments per agent group.",
   "license": "AGPL-3.0",

--- a/web/ui/src/components/StatusDot.tsx
+++ b/web/ui/src/components/StatusDot.tsx
@@ -1,0 +1,43 @@
+import type { GroupStatus } from "../lib/api.ts";
+
+export function StatusDot({ status }: { status: GroupStatus | null }) {
+  if (!status) {
+    return <span className="status-dot status-dot-unknown" title="status unavailable" aria-label="status unavailable" />;
+  }
+  if (status.containerRunning) {
+    const lastActive = status.lastHeartbeatAt
+      ? `last heartbeat ${formatRelative(status.lastHeartbeatAt)}`
+      : "alive";
+    return (
+      <span
+        className="status-dot status-dot-alive"
+        title={`${status.activeSessionCount} session${status.activeSessionCount === 1 ? "" : "s"} alive — ${lastActive}`}
+        aria-label="alive"
+      />
+    );
+  }
+  const idleTitle = status.lastHeartbeatAt
+    ? `idle — last heartbeat ${formatRelative(status.lastHeartbeatAt)}`
+    : "idle — never started";
+  return (
+    <span
+      className="status-dot status-dot-idle"
+      title={idleTitle}
+      aria-label="idle"
+    />
+  );
+}
+
+export function formatRelative(iso: string, nowMs: number = Date.now()): string {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return iso;
+  const diffSec = Math.max(0, Math.floor((nowMs - t) / 1000));
+  if (diffSec < 5) return "just now";
+  if (diffSec < 60) return `${diffSec}s ago`;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.floor(diffHr / 24);
+  return `${diffDay}d ago`;
+}

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -16,6 +16,28 @@ export interface VaultAttachment {
   attachedAt: string;
 }
 
+export interface SessionStatus {
+  sessionId: string;
+  status: "active" | "closed";
+  containerStatus: "running" | "idle" | "stopped";
+  alive: boolean;
+  lastHeartbeatAt: string | null;
+  lastMessageInAt: string | null;
+  lastMessageOutAt: string | null;
+  createdAt: string;
+  lastActiveAt: string | null;
+}
+
+export interface GroupStatus {
+  containerRunning: boolean;
+  activeSessionCount: number;
+  sessionCount: number;
+  lastHeartbeatAt: string | null;
+  lastMessageInAt: string | null;
+  lastMessageOutAt: string | null;
+  sessions: SessionStatus[];
+}
+
 export interface AgentGroupView {
   id: string;
   name: string;
@@ -23,6 +45,7 @@ export interface AgentGroupView {
   agent_provider: string | null;
   created_at: string;
   vault: VaultAttachment | null;
+  status: GroupStatus | null;
 }
 
 async function request<T>(

--- a/web/ui/src/routes/GroupDetail.tsx
+++ b/web/ui/src/routes/GroupDetail.tsx
@@ -1,13 +1,17 @@
 import { useCallback, useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { ScopeGrants, SCOPE_OPTIONS } from "../components/ScopeGrants.tsx";
+import { StatusDot, formatRelative } from "../components/StatusDot.tsx";
 import {
   attachVault,
   detachVault,
   getGroup,
   type AgentGroupView,
+  type GroupStatus,
   type VaultScope,
 } from "../lib/api.ts";
+
+const POLL_MS = 7_000;
 
 export function GroupDetail() {
   const { folder } = useParams<{ folder: string }>();
@@ -43,6 +47,17 @@ export function GroupDetail() {
   useEffect(() => {
     void reload();
   }, [reload]);
+
+  // Background poll for live status — silent on failure.
+  useEffect(() => {
+    if (!folder || !group) return;
+    const t = setInterval(() => {
+      getGroup(folder)
+        .then((g) => setGroup(g))
+        .catch(() => {});
+    }, POLL_MS);
+    return () => clearInterval(t);
+  }, [folder, group]);
 
   const onAttach = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -139,6 +154,7 @@ export function GroupDetail() {
     <div>
       <Link to="/" className="muted">← All groups</Link>
       <h2 style={{ display: "flex", alignItems: "center", gap: "0.6rem" }}>
+        <StatusDot status={group.status} />
         {group.name}
         {group.vault ? (
           <span className="tag">{group.vault.scope}</span>
@@ -163,6 +179,8 @@ export function GroupDetail() {
           <div>created</div><div>{new Date(group.created_at).toLocaleString()}</div>
         </div>
       </div>
+
+      {group.status && <StatusSection status={group.status} />}
 
       {group.vault ? (
         <div className="section">
@@ -292,3 +310,81 @@ export function GroupDetail() {
   );
 }
 
+function StatusSection({ status }: { status: GroupStatus }) {
+  return (
+    <div className="section">
+      <h3>Live status</h3>
+      <div className="kv">
+        <div>container</div>
+        <div>
+          {status.containerRunning ? (
+            <span className="status-text alive">running</span>
+          ) : (
+            <span className="status-text idle">idle</span>
+          )}
+        </div>
+        <div>active sessions</div>
+        <div>{status.activeSessionCount} of {status.sessionCount}</div>
+        <div>last heartbeat</div>
+        <div>
+          {status.lastHeartbeatAt ? (
+            <>
+              {formatRelative(status.lastHeartbeatAt)}{" "}
+              <span className="dim">({new Date(status.lastHeartbeatAt).toLocaleString()})</span>
+            </>
+          ) : (
+            <span className="dim">never</span>
+          )}
+        </div>
+        <div>last message in</div>
+        <div>
+          {status.lastMessageInAt ? (
+            <>
+              {formatRelative(status.lastMessageInAt)}{" "}
+              <span className="dim">({new Date(status.lastMessageInAt).toLocaleString()})</span>
+            </>
+          ) : (
+            <span className="dim">none</span>
+          )}
+        </div>
+        <div>last message out</div>
+        <div>
+          {status.lastMessageOutAt ? (
+            <>
+              {formatRelative(status.lastMessageOutAt)}{" "}
+              <span className="dim">({new Date(status.lastMessageOutAt).toLocaleString()})</span>
+            </>
+          ) : (
+            <span className="dim">none</span>
+          )}
+        </div>
+      </div>
+      {status.sessions.length > 0 && (
+        <>
+          <hr className="sep" />
+          <div className="dim" style={{ marginBottom: "0.5rem" }}>
+            Sessions ({status.sessions.length}):
+          </div>
+          <ul className="session-list">
+            {status.sessions.map((s) => (
+              <li key={s.sessionId}>
+                <code>{s.sessionId}</code>{" "}
+                {s.alive ? (
+                  <span className="status-text alive">alive</span>
+                ) : (
+                  <span className="status-text idle">{s.containerStatus}</span>
+                )}{" "}
+                <span className="dim">— {s.status}</span>
+                {s.lastHeartbeatAt && (
+                  <>
+                    {" "}<span className="dim">· hb {formatRelative(s.lastHeartbeatAt)}</span>
+                  </>
+                )}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/ui/src/routes/GroupList.tsx
+++ b/web/ui/src/routes/GroupList.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { StatusDot, formatRelative } from "../components/StatusDot.tsx";
 import { listGroups, type AgentGroupView } from "../lib/api.ts";
+
+const POLL_MS = 7_000;
 
 export function GroupList() {
   const [state, setState] = useState<
@@ -15,6 +18,7 @@ export function GroupList() {
     setReloadKey((k) => k + 1);
   }, []);
 
+  // Initial load + manual reload.
   useEffect(() => {
     let cancelled = false;
     listGroups()
@@ -31,6 +35,25 @@ export function GroupList() {
       cancelled = true;
     };
   }, [reloadKey]);
+
+  // Background poll — refresh status without flipping back to loading state.
+  useEffect(() => {
+    if (state.kind !== "ok") return;
+    let cancelled = false;
+    const t = setInterval(() => {
+      listGroups()
+        .then((groups) => {
+          if (!cancelled) setState({ kind: "ok", groups });
+        })
+        .catch(() => {
+          // Polling error is silent — leave the last good snapshot in view.
+        });
+    }, POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, [state.kind]);
 
   if (state.kind === "loading") {
     return (
@@ -112,6 +135,7 @@ export function GroupList() {
           className="group-row"
         >
           <div className="name">
+            <StatusDot status={g.status} />
             {g.name}
             {g.vault ? (
               <span className="tag">{g.vault.scope}</span>
@@ -123,6 +147,16 @@ export function GroupList() {
             folder: <code>{g.folder}</code>
             {g.agent_provider && (
               <> &middot; provider: <code>{g.agent_provider}</code></>
+            )}
+            {g.status && g.status.containerRunning && (
+              <> &middot; <span className="status-text alive">
+                {g.status.activeSessionCount} session{g.status.activeSessionCount === 1 ? "" : "s"} alive
+              </span></>
+            )}
+            {g.status && !g.status.containerRunning && g.status.lastHeartbeatAt && (
+              <> &middot; <span className="status-text idle">
+                idle &middot; last active {formatRelative(g.status.lastHeartbeatAt)}
+              </span></>
             )}
             {g.vault && (
               <>

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -356,3 +356,41 @@ hr.sep { border: 0; border-top: 1px solid var(--border); margin: 1.5rem 0; }
   font-size: 0.85rem;
   color: var(--error);
 }
+
+/* Status indicators */
+.status-dot {
+  display: inline-block;
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  flex-shrink: 0;
+  vertical-align: middle;
+}
+.status-dot-alive {
+  background: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.status-dot-idle {
+  background: var(--fg-dim);
+}
+.status-dot-unknown {
+  background: transparent;
+  border: 1px dashed var(--fg-dim);
+}
+.status-text.alive { color: var(--accent); font-weight: 500; }
+.status-text.idle { color: var(--fg-muted); }
+
+.session-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.88rem;
+}
+.session-list li {
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  padding: 0.5rem 0.7rem;
+  border-radius: 6px;
+}


### PR DESCRIPTION
Closes #5.

Each agent group in the web UI now reflects whether its container is currently running plus recent activity, so an operator can see at a glance which agents are alive right now.

## Liveness signal

Cross-process: the web server and NanoClaw's host process are different processes, so `isContainerRunning(sessionId)` (in-memory map in `container-runner.ts`) is not visible to us. The heartbeat file mtime at `data/v2-sessions/<agent_group_id>/<session_id>/.heartbeat` — touched by the container's agent-runner on every poll iteration — is the only cross-process liveness signal.

Threshold: 90s. NanoClaw's host sweep runs every 60s; +30s grace keeps the alive dot from blinking during a sweep tick.

## Shape

- Helper: `src/parachute/group-status.ts` — `getGroupStatus(folder)` returns container-running, active-session-count, last-heartbeat / last-message-in / last-message-out, plus per-session detail. No upstream NanoClaw files modified.
- Tests: `src/parachute/group-status.test.ts` — 6 vitest cases (unknown folder, no sessions, fresh heartbeat → alive, stale heartbeat → dead, aggregate latest message timestamps across sessions, tolerate missing dirs/DBs). Full suite 203/203.
- API: extended onto existing `GET /api/groups` and `GET /api/groups/:folder` rather than a new endpoint — fewer endpoints, list typically holds 1-10 groups so computing status for all is cheap (one `stat()` + 2 readonly sqlite opens per session).
- UI: `StatusDot` + `formatRelative` shared component; `GroupList` + `GroupDetail` poll every 7s, silent on failure (last good snapshot stays in view).

## Out of scope (per the issue)

Container lifecycle controls, session inspection / log viewer, historical metrics. Just the live "is it alive?" read-out.

## Versions

`web/server` and `web/ui` 0.0.3-rc.1 → 0.0.4-rc.1 (behavior change).