### PR TITLE
feat(web): operator auth via hub OAuth (closes #4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "better-sqlite3": "11.10.0",
     "chat": "^4.24.0",
     "cron-parser": "5.5.0",
+    "jose": "^6.2.2",
     "kleur": "^4.1.5"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       cron-parser:
         specifier: 5.5.0
         version: 5.5.0
+      jose:
+        specifier: ^6.2.2
+        version: 6.2.2
       kleur:
         specifier: ^4.1.5
         version: 4.1.5
@@ -873,6 +876,9 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -2229,6 +2235,8 @@ snapshots:
   is-plain-obj@4.1.0: {}
 
   isexe@2.0.0: {}
+
+  jose@6.2.2: {}
 
   js-yaml@4.1.1:
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     // container/agent-runner tests run under Bun (they depend on bun:sqlite).
     // See container/agent-runner/package.json "test" script.
-    include: ['src/**/*.test.ts', 'setup/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'setup/**/*.test.ts', 'web/server/src/**/*.test.ts'],
   },
 });

--- a/web/server/package.json
+++ b/web/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraclaw/web-server",
-  "version": "0.0.4-rc.1",
+  "version": "0.0.5-rc.1",
   "private": true,
   "description": "Paraclaw web UI server. Lists agent groups + manages vault attachments. Reuses NanoClaw's better-sqlite3 + Parachute attach helpers.",
   "license": "AGPL-3.0",

--- a/web/server/src/auth.test.ts
+++ b/web/server/src/auth.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Hub-JWT validation + scope-check tests. Mirrors vault's hub-jwt.test.ts
+ * shape but uses vitest + node:http (paraclaw's suite is vitest, not
+ * bun:test). A fake JWKS endpoint signs locally with a known RSA keypair;
+ * cases cover the spec failure modes plus paraclaw's claw-scope inheritance
+ * + vault:admin catch-all.
+ */
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { exportJWK, generateKeyPair, SignJWT } from 'jose';
+
+import {
+  authenticate,
+  hasScope,
+  HubJwtError,
+  resetJwksCache,
+  SCOPE_CLAW_ADMIN,
+  SCOPE_CLAW_READ,
+  SCOPE_CLAW_WRITE,
+  SCOPE_VAULT_ADMIN,
+  validateHubJwt,
+} from './auth.js';
+
+interface Keypair {
+  // jose's generateKeyPair returns CryptoKey under WebCrypto; type narrowly to
+  // avoid pulling in lib.dom.
+  privateKey: Awaited<ReturnType<typeof generateKeyPair>>['privateKey'];
+  publicJwk: { kty: string; n: string; e: string; kid: string; alg: string; use: string };
+  kid: string;
+}
+
+async function makeKeypair(kid: string): Promise<Keypair> {
+  const { privateKey, publicKey } = await generateKeyPair('RS256', { extractable: true });
+  const jwk = await exportJWK(publicKey);
+  return {
+    privateKey,
+    publicJwk: {
+      kty: 'RSA',
+      n: jwk.n!,
+      e: jwk.e!,
+      kid,
+      alg: 'RS256',
+      use: 'sig',
+    },
+    kid,
+  };
+}
+
+interface JwksFixture {
+  origin: string;
+  stop: () => Promise<void>;
+  setKeys: (keys: Keypair[]) => void;
+  setUnreachable: (down: boolean) => void;
+}
+
+function startJwksFixture(): Promise<JwksFixture> {
+  return new Promise((resolve) => {
+    let keys: Keypair[] = [];
+    let down = false;
+    const server = http.createServer((req, res) => {
+      if (req.url !== '/.well-known/jwks.json') {
+        res.writeHead(404).end('not found');
+        return;
+      }
+      if (down) {
+        res.writeHead(503).end('upstream down');
+        return;
+      }
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ keys: keys.map((k) => k.publicJwk) }));
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({
+        origin: `http://127.0.0.1:${port}`,
+        stop: () =>
+          new Promise<void>((r) => {
+            server.close(() => r());
+          }),
+        setKeys: (next) => {
+          keys = next;
+        },
+        setUnreachable: (v) => {
+          down = v;
+        },
+      });
+    });
+  });
+}
+
+interface SignOpts {
+  iss?: string;
+  aud?: string;
+  sub?: string;
+  scope?: string;
+  ttlSeconds?: number;
+  expiresAtSeconds?: number;
+  kid?: string;
+  clientId?: string;
+}
+
+async function signJwt(kp: Keypair, opts: SignOpts): Promise<string> {
+  const iat = Math.floor(Date.now() / 1000);
+  const exp = opts.expiresAtSeconds ?? iat + (opts.ttlSeconds ?? 60);
+  return await new SignJWT({
+    scope: opts.scope ?? 'claw:read',
+    client_id: opts.clientId ?? 'test-client',
+  })
+    .setProtectedHeader({ alg: 'RS256', kid: opts.kid ?? kp.kid })
+    .setIssuer(opts.iss ?? 'http://issuer.invalid')
+    .setSubject(opts.sub ?? 'user-1')
+    .setAudience(opts.aud ?? 'hub')
+    .setIssuedAt(iat)
+    .setExpirationTime(exp)
+    .setJti('jti-1')
+    .sign(kp.privateKey);
+}
+
+let fixture: JwksFixture;
+let kp: Keypair;
+let prevHubOrigin: string | undefined;
+
+beforeAll(async () => {
+  fixture = await startJwksFixture();
+  kp = await makeKeypair('k1');
+  fixture.setKeys([kp]);
+});
+
+afterAll(async () => {
+  await fixture.stop();
+  if (prevHubOrigin === undefined) delete process.env.PARACLAW_HUB_ORIGIN;
+  else process.env.PARACLAW_HUB_ORIGIN = prevHubOrigin;
+});
+
+beforeEach(() => {
+  prevHubOrigin = process.env.PARACLAW_HUB_ORIGIN;
+  process.env.PARACLAW_HUB_ORIGIN = fixture.origin;
+  fixture.setUnreachable(false);
+  fixture.setKeys([kp]);
+  resetJwksCache();
+});
+
+afterEach(() => {
+  if (prevHubOrigin === undefined) delete process.env.PARACLAW_HUB_ORIGIN;
+  else process.env.PARACLAW_HUB_ORIGIN = prevHubOrigin;
+});
+
+describe('validateHubJwt', () => {
+  it('happy path — surfaces sub + scopes + clientId', async () => {
+    const token = await signJwt(kp, { iss: fixture.origin, scope: 'claw:read claw:write' });
+    const claims = await validateHubJwt(token);
+    expect(claims.sub).toBe('user-1');
+    expect(claims.scopes).toEqual(['claw:read', 'claw:write']);
+    expect(claims.clientId).toBe('test-client');
+  });
+
+  it('rejects token with wrong issuer', async () => {
+    const token = await signJwt(kp, { iss: 'http://attacker.example' });
+    await expect(validateHubJwt(token)).rejects.toBeInstanceOf(HubJwtError);
+  });
+
+  it('rejects expired token', async () => {
+    const past = Math.floor(Date.now() / 1000) - 10;
+    const token = await signJwt(kp, { iss: fixture.origin, expiresAtSeconds: past });
+    await expect(validateHubJwt(token)).rejects.toBeInstanceOf(HubJwtError);
+  });
+
+  it('rejects token signed by an unpublished key', async () => {
+    const otherKp = await makeKeypair('k1');
+    const token = await signJwt(otherKp, { iss: fixture.origin });
+    await expect(validateHubJwt(token)).rejects.toBeInstanceOf(HubJwtError);
+  });
+
+  it('rejects when JWKS endpoint is unreachable', async () => {
+    fixture.setUnreachable(true);
+    const token = await signJwt(kp, { iss: fixture.origin });
+    await expect(validateHubJwt(token)).rejects.toBeInstanceOf(HubJwtError);
+  });
+});
+
+describe('hasScope', () => {
+  it('exact match', () => {
+    expect(hasScope([SCOPE_CLAW_READ], SCOPE_CLAW_READ)).toBe(true);
+  });
+
+  it('claw:admin ⊇ claw:write ⊇ claw:read', () => {
+    expect(hasScope([SCOPE_CLAW_ADMIN], SCOPE_CLAW_READ)).toBe(true);
+    expect(hasScope([SCOPE_CLAW_ADMIN], SCOPE_CLAW_WRITE)).toBe(true);
+    expect(hasScope([SCOPE_CLAW_WRITE], SCOPE_CLAW_READ)).toBe(true);
+    expect(hasScope([SCOPE_CLAW_READ], SCOPE_CLAW_WRITE)).toBe(false);
+    expect(hasScope([SCOPE_CLAW_WRITE], SCOPE_CLAW_ADMIN)).toBe(false);
+  });
+
+  it('vault:admin (operator-token catch-all) satisfies every claw scope', () => {
+    expect(hasScope([SCOPE_VAULT_ADMIN], SCOPE_CLAW_READ)).toBe(true);
+    expect(hasScope([SCOPE_VAULT_ADMIN], SCOPE_CLAW_WRITE)).toBe(true);
+    expect(hasScope([SCOPE_VAULT_ADMIN], SCOPE_CLAW_ADMIN)).toBe(true);
+  });
+
+  it('hub:admin does NOT satisfy claw scopes', () => {
+    expect(hasScope(['hub:admin'], SCOPE_CLAW_READ)).toBe(false);
+    expect(hasScope(['hub:admin'], SCOPE_CLAW_WRITE)).toBe(false);
+    expect(hasScope(['hub:admin'], SCOPE_CLAW_ADMIN)).toBe(false);
+  });
+
+  it('empty scopes never satisfy', () => {
+    expect(hasScope([], SCOPE_CLAW_READ)).toBe(false);
+  });
+});
+
+describe('authenticate', () => {
+  it('returns ok with claims for a valid Bearer + sufficient scope', async () => {
+    const token = await signJwt(kp, { iss: fixture.origin, scope: 'claw:write' });
+    const r = await authenticate(`Bearer ${token}`, SCOPE_CLAW_READ);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.claims.scopes).toContain('claw:write');
+  });
+
+  it('401 on missing header', async () => {
+    const r = await authenticate(undefined, SCOPE_CLAW_READ);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.status).toBe(401);
+  });
+
+  it('401 on malformed header (no Bearer prefix)', async () => {
+    const token = await signJwt(kp, { iss: fixture.origin });
+    const r = await authenticate(token, SCOPE_CLAW_READ);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.status).toBe(401);
+  });
+
+  it('401 on invalid token (wrong issuer)', async () => {
+    const token = await signJwt(kp, { iss: 'http://attacker.example' });
+    const r = await authenticate(`Bearer ${token}`, SCOPE_CLAW_READ);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.status).toBe(401);
+  });
+
+  it('403 on insufficient scope — surfaces error_type + required + granted', async () => {
+    const token = await signJwt(kp, { iss: fixture.origin, scope: 'claw:read' });
+    const r = await authenticate(`Bearer ${token}`, SCOPE_CLAW_WRITE);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.status).toBe(403);
+      expect(r.errorType).toBe('insufficient_scope');
+      expect(r.requiredScope).toBe(SCOPE_CLAW_WRITE);
+      expect(r.grantedScopes).toEqual(['claw:read']);
+    }
+  });
+
+  it('operator-token shape (vault:admin scope) passes any claw gate', async () => {
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      scope: 'hub:admin vault:admin scribe:admin channel:send',
+    });
+    const r = await authenticate(`Bearer ${token}`, SCOPE_CLAW_ADMIN);
+    expect(r.ok).toBe(true);
+  });
+});

--- a/web/server/src/auth.ts
+++ b/web/server/src/auth.ts
@@ -1,0 +1,190 @@
+/**
+ * Hub-issued JWT validation. Paraclaw's web server as resource server: trusts
+ * tokens that the hub signs against keys we fetch from `/.well-known/jwks.json`.
+ *
+ * Shape mirrors `parachute-vault/src/hub-jwt.ts` deliberately — same trust
+ * model, same load-bearing checks (`iss` strict; `aud` parsed not enforced).
+ * The shared scope-guard library proposed in cli#59 will eventually absorb
+ * both.
+ *
+ * Hub origin resolution: `PARACLAW_HUB_ORIGIN` env override → loopback
+ * `http://127.0.0.1:1939`. We intentionally do NOT read services.json — the
+ * hub is the dispatcher, not a registered service in that file (matching
+ * vault's choice).
+ *
+ * Scope vocabulary introduced here: `claw:read` / `claw:write` / `claw:admin`
+ * with `admin ⊇ write ⊇ read` inheritance per
+ * `parachute-patterns/patterns/oauth-scopes.md`. `vault:admin` is the
+ * operator-token catch-all and satisfies any claw scope check (operator
+ * token is what local CLI/scripts present; it carries `vault:admin` per
+ * `parachute-hub/src/operator-token.ts`).
+ */
+import { createRemoteJWKSet, jwtVerify, type JWTPayload } from 'jose';
+
+const DEFAULT_HUB_LOOPBACK = 'http://127.0.0.1:1939';
+
+export const SCOPE_CLAW_READ = 'claw:read' as const;
+export const SCOPE_CLAW_WRITE = 'claw:write' as const;
+export const SCOPE_CLAW_ADMIN = 'claw:admin' as const;
+export const SCOPE_VAULT_ADMIN = 'vault:admin' as const;
+
+export type ClawScope =
+  | typeof SCOPE_CLAW_READ
+  | typeof SCOPE_CLAW_WRITE
+  | typeof SCOPE_CLAW_ADMIN;
+
+export function getHubOrigin(): string {
+  const env = process.env.PARACLAW_HUB_ORIGIN?.replace(/\/$/, '');
+  if (env && env.length > 0) return env;
+  return DEFAULT_HUB_LOOPBACK;
+}
+
+export interface HubJwtClaims {
+  sub: string;
+  scopes: string[];
+  aud: string | undefined;
+  jti: string | undefined;
+  clientId: string | undefined;
+}
+
+export class HubJwtError extends Error {
+  override name = 'HubJwtError';
+}
+
+type JwksGetter = ReturnType<typeof createRemoteJWKSet>;
+let cachedGetter: JwksGetter | null = null;
+let cachedOrigin: string | null = null;
+
+function getJwksGetter(origin: string): JwksGetter {
+  if (cachedGetter && cachedOrigin === origin) return cachedGetter;
+  cachedGetter = createRemoteJWKSet(new URL(`${origin}/.well-known/jwks.json`), {
+    cacheMaxAge: 5 * 60 * 1000,
+    cooldownDuration: 30 * 1000,
+  });
+  cachedOrigin = origin;
+  return cachedGetter;
+}
+
+export function resetJwksCache(): void {
+  cachedGetter = null;
+  cachedOrigin = null;
+}
+
+/**
+ * Verify a presented JWT against the hub's JWKS. Throws `HubJwtError` on any
+ * failure. The `iss` claim MUST equal the configured hub origin — load-bearing
+ * trust check; without it, anyone could mint a token against any RSA key and
+ * pass verification.
+ */
+export async function validateHubJwt(token: string): Promise<HubJwtClaims> {
+  const origin = getHubOrigin();
+  const getter = getJwksGetter(origin);
+
+  let payload: JWTPayload;
+  try {
+    const verified = await jwtVerify(token, getter, { issuer: origin });
+    payload = verified.payload;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new HubJwtError(`hub JWT verification failed: ${msg}`);
+  }
+
+  if (typeof payload.sub !== 'string' || payload.sub.length === 0) {
+    throw new HubJwtError('hub JWT missing required `sub` claim');
+  }
+
+  const scopeRaw = (payload as { scope?: unknown }).scope;
+  const scopes = typeof scopeRaw === 'string' ? parseScopes(scopeRaw) : [];
+  const aud = typeof payload.aud === 'string' ? payload.aud : undefined;
+  const jti = typeof payload.jti === 'string' ? payload.jti : undefined;
+  const clientIdRaw = (payload as { client_id?: unknown }).client_id;
+  const clientId = typeof clientIdRaw === 'string' ? clientIdRaw : undefined;
+
+  return { sub: payload.sub, scopes, aud, jti, clientId };
+}
+
+export function parseScopes(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(/\s+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Does `granted` satisfy `required`?
+ *
+ * Inheritance rules:
+ *   - `claw:admin` ⊇ `claw:write` ⊇ `claw:read`
+ *   - `vault:admin` (operator-token catch-all) satisfies every `claw:*`
+ *   - `hub:admin` does NOT — narrow boundary; admins of the hub identity
+ *     surface aren't implicitly admins of every resource server.
+ */
+export function hasScope(granted: string[], required: ClawScope): boolean {
+  if (granted.includes(required)) return true;
+  if (granted.includes(SCOPE_VAULT_ADMIN)) return true;
+  if (required === SCOPE_CLAW_READ) {
+    return granted.includes(SCOPE_CLAW_WRITE) || granted.includes(SCOPE_CLAW_ADMIN);
+  }
+  if (required === SCOPE_CLAW_WRITE) {
+    return granted.includes(SCOPE_CLAW_ADMIN);
+  }
+  return false;
+}
+
+export interface AuthOk {
+  ok: true;
+  claims: HubJwtClaims;
+}
+export interface AuthFail {
+  ok: false;
+  status: 401 | 403;
+  error: string;
+  errorType?: 'insufficient_scope';
+  requiredScope?: ClawScope;
+  grantedScopes?: string[];
+}
+export type AuthResult = AuthOk | AuthFail;
+
+function extractBearer(header: string | undefined): string | null {
+  if (!header) return null;
+  const m = header.match(/^Bearer\s+(.+)$/i);
+  return m ? m[1].trim() : null;
+}
+
+/**
+ * Single seam every `/api/*` handler runs through. Pulls `Authorization:
+ * Bearer <jwt>` off the request, validates it, checks scope. Returns
+ * structured pass/fail rather than throwing so callers can shape the
+ * response uniformly (RFC-6749-style 403 body for insufficient_scope).
+ */
+export async function authenticate(
+  authHeader: string | undefined,
+  required: ClawScope,
+): Promise<AuthResult> {
+  const token = extractBearer(authHeader);
+  if (!token) {
+    return { ok: false, status: 401, error: 'missing or malformed Authorization header' };
+  }
+  let claims: HubJwtClaims;
+  try {
+    claims = await validateHubJwt(token);
+  } catch (err) {
+    return {
+      ok: false,
+      status: 401,
+      error: err instanceof HubJwtError ? err.message : 'token validation failed',
+    };
+  }
+  if (!hasScope(claims.scopes, required)) {
+    return {
+      ok: false,
+      status: 403,
+      error: `This endpoint requires the '${required}' scope.`,
+      errorType: 'insufficient_scope',
+      requiredScope: required,
+      grantedScopes: claims.scopes,
+    };
+  }
+  return { ok: true, claims };
+}

--- a/web/server/src/server.ts
+++ b/web/server/src/server.ts
@@ -10,9 +10,15 @@
  * just exposes /api/*. In dev, run vite separately on port 5173 with the
  * proxy in vite.config.ts pointing back to this server.
  *
- * Auth model for v1: server runs locally, binds 127.0.0.1, no auth.
- * Anyone with shell access to your laptop can act as you. Phase B replaces
- * with vault OAuth handshake.
+ * Auth model: every `/api/*` route requires a hub-issued JWT — operator
+ * token (CLI/scripts) or user OAuth (browser) — validated via JWKS against
+ * the hub origin. Loopback bind is no longer load-bearing for safety; a
+ * compromised browser extension on the same machine can hit 127.0.0.1, so
+ * every endpoint auths. See `auth.ts` for the validation seam.
+ *
+ * Two endpoints stay unauthenticated: `/api/health` (operational probe)
+ * and `/api/discovery` (returns hub origin so the SPA can bootstrap its
+ * OAuth flow without baking the origin into the bundle).
  */
 // MUST be first — chdirs to project root so NanoClaw's config.ts resolves
 // DATA_DIR / GROUPS_DIR correctly regardless of where the server was invoked.
@@ -43,6 +49,14 @@ import {
   validateFolderSlug,
 } from '../../../src/parachute/create-agent.js';
 import { getGroupStatus, type GroupStatus } from '../../../src/parachute/group-status.js';
+import {
+  authenticate,
+  getHubOrigin,
+  SCOPE_CLAW_READ,
+  SCOPE_CLAW_WRITE,
+  type AuthResult,
+  type ClawScope,
+} from './auth.js';
 
 const CENTRAL_DB_PATH = path.join(DATA_DIR, 'v2.db');
 
@@ -186,6 +200,34 @@ async function readJsonBody<T>(req: http.IncomingMessage): Promise<T> {
 
 const VALID_SCOPES: VaultScope[] = ['vault:read', 'vault:write', 'vault:admin'];
 
+function send401or403(res: http.ServerResponse, fail: Extract<AuthResult, { ok: false }>): void {
+  const body: Record<string, unknown> = { error: fail.error };
+  if (fail.errorType) body.error_type = fail.errorType;
+  if (fail.requiredScope) body.required_scope = fail.requiredScope;
+  if (fail.grantedScopes) body.granted_scopes = fail.grantedScopes;
+  // RFC 6750 challenge for 401; insufficient_scope challenge for 403.
+  if (fail.status === 401) {
+    res.setHeader('WWW-Authenticate', 'Bearer');
+  } else if (fail.errorType === 'insufficient_scope' && fail.requiredScope) {
+    res.setHeader(
+      'WWW-Authenticate',
+      `Bearer error="insufficient_scope", scope="${fail.requiredScope}"`,
+    );
+  }
+  json(res, fail.status, body);
+}
+
+async function gate(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  required: ClawScope,
+): Promise<boolean> {
+  const result = await authenticate(req.headers.authorization, required);
+  if (result.ok) return true;
+  send401or403(res, result);
+  return false;
+}
+
 async function handleApi(
   req: http.IncomingMessage,
   res: http.ServerResponse,
@@ -194,17 +236,26 @@ async function handleApi(
   const { pathname } = url;
   const method = req.method ?? 'GET';
 
+  // Unauthenticated probes: liveness check and OAuth-bootstrap discovery.
+  // Discovery surfaces the hub origin so the SPA can reach the AS metadata
+  // (`/.well-known/oauth-authorization-server`) without hard-coding it.
   if (pathname === '/api/health' && method === 'GET') {
     json(res, 200, {
       service: 'paraclaw-web-server',
-      version: '0.0.4-rc.1',
+      version: '0.0.5-rc.1',
       data_dir: DATA_DIR,
       groups_dir: GROUPS_DIR,
     });
     return;
   }
 
+  if (pathname === '/api/discovery' && method === 'GET') {
+    json(res, 200, { hubOrigin: getHubOrigin() });
+    return;
+  }
+
   if (pathname === '/api/groups' && method === 'GET') {
+    if (!(await gate(req, res, SCOPE_CLAW_READ))) return;
     try {
       const groups = listAgentGroups();
       json(res, 200, { groups });
@@ -215,6 +266,7 @@ async function handleApi(
   }
 
   if (pathname === '/api/groups' && method === 'POST') {
+    if (!(await gate(req, res, SCOPE_CLAW_WRITE))) return;
     try {
       const body = await readJsonBody<{
         name?: string;
@@ -287,9 +339,11 @@ async function handleApi(
   }
 
   // GET /api/folder-availability/:slug — used by the new-agent wizard for
-  // live "is this slug free?" feedback.
+  // live "is this slug free?" feedback. Read-gated: the slug namespace is
+  // operator-private state.
   const folderAvail = pathname.match(/^\/api\/folder-availability\/([^/]+)$/);
   if (folderAvail && method === 'GET') {
+    if (!(await gate(req, res, SCOPE_CLAW_READ))) return;
     const slug = decodeURIComponent(folderAvail[1]);
     const v = validateFolderSlug(slug);
     if (!v.ok) {
@@ -301,8 +355,10 @@ async function handleApi(
   }
 
   // GET /api/folder-suggestion?name=... — wizard uses this to seed the slug
-  // input from the agent name.
+  // input from the agent name. Pure transform but kept behind read-gate so
+  // the auth-required surface is uniform.
   if (pathname === '/api/folder-suggestion' && method === 'GET') {
+    if (!(await gate(req, res, SCOPE_CLAW_READ))) return;
     const name = url.searchParams.get('name') ?? '';
     json(res, 200, { name, slug: suggestFolderSlug(name) });
     return;
@@ -313,6 +369,14 @@ async function handleApi(
   if (groupRoute) {
     const folder = decodeURIComponent(groupRoute[1]);
     const sub = groupRoute[2] ?? '';
+
+    // Pick the scope for the matching sub-route up front so we can gate
+    // before any DB read. GET → read; POST → write.
+    const requiredScope: ClawScope =
+      sub === '' && method === 'GET'
+        ? SCOPE_CLAW_READ
+        : SCOPE_CLAW_WRITE;
+    if (!(await gate(req, res, requiredScope))) return;
 
     const group = getAgentGroup(folder);
     if (!group) {

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraclaw/web-ui",
-  "version": "0.0.4-rc.1",
+  "version": "0.0.5-rc.1",
   "private": true,
   "description": "Paraclaw web UI — Vite + React + TypeScript. Manages vault attachments per agent group.",
   "license": "AGPL-3.0",

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -1,9 +1,25 @@
-import { Link, Route, Routes } from "react-router-dom";
+import { Link, Route, Routes, useLocation } from "react-router-dom";
 import { GroupList } from "./routes/GroupList.tsx";
 import { GroupDetail } from "./routes/GroupDetail.tsx";
 import { NewGroupWizard } from "./routes/NewGroupWizard.tsx";
+import { OAuthCallback } from "./routes/OAuthCallback.tsx";
 
 export function App() {
+  // The OAuth callback page is intentionally chrome-free — the user is
+  // mid-handoff back from the hub and the nav frame would just be noise.
+  const location = useLocation();
+  const isCallback = location.pathname === "/oauth/callback";
+
+  if (isCallback) {
+    return (
+      <div className="page">
+        <Routes>
+          <Route path="/oauth/callback" element={<OAuthCallback />} />
+        </Routes>
+      </div>
+    );
+  }
+
   return (
     <div className="page">
       <nav className="nav">

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -3,7 +3,13 @@
  *
  * In dev: Vite proxies /api/* to localhost:4944.
  * In prod: server serves the built UI under /claw/, /api/* on the same origin.
+ *
+ * Auth: every /api/* request gets `Authorization: Bearer <jwt>` from the
+ * hub-OAuth flow in `./auth.ts`. On a 401 we refresh once; if the refresh
+ * fails the wrapper hard-redirects to login. /api/discovery is the one
+ * exception — it's the bootstrap and is fetched directly by auth.ts.
  */
+import { beginLogin, clearTokens, getAccessToken, refreshAccessToken } from "./auth.ts";
 
 const API_BASE = "/api";
 
@@ -48,31 +54,61 @@ export interface AgentGroupView {
   status: GroupStatus | null;
 }
 
-async function request<T>(
+async function doFetch(
   path: string,
-  init?: RequestInit & { json?: unknown },
-): Promise<T> {
+  init: RequestInit & { json?: unknown } | undefined,
+  bearer: string | null,
+): Promise<Response> {
   const headers: Record<string, string> = {
     Accept: "application/json",
     ...((init?.headers as Record<string, string>) ?? {}),
   };
+  if (bearer) headers.Authorization = `Bearer ${bearer}`;
   let body: BodyInit | undefined = init?.body as BodyInit | undefined;
   if (init?.json !== undefined) {
     headers["Content-Type"] = "application/json";
     body = JSON.stringify(init.json);
   }
-  const res = await fetch(`${API_BASE}${path}`, { ...init, headers, body });
-  if (!res.ok) {
-    let message = `${res.status} ${res.statusText}`;
-    try {
-      const text = await res.text();
-      const parsed = JSON.parse(text) as { error?: string };
-      if (parsed.error) message = parsed.error;
-      else if (text) message = text;
-    } catch {
-      // not JSON, use status
+  return fetch(`${API_BASE}${path}`, { ...init, headers, body });
+}
+
+async function readError(res: Response): Promise<string> {
+  let message = `${res.status} ${res.statusText}`;
+  try {
+    const text = await res.text();
+    const parsed = JSON.parse(text) as { error?: string };
+    if (parsed.error) message = parsed.error;
+    else if (text) message = text;
+  } catch {
+    // not JSON, use status
+  }
+  return message;
+}
+
+export async function request<T>(
+  path: string,
+  init?: RequestInit & { json?: unknown },
+): Promise<T> {
+  let bearer = getAccessToken();
+  if (!bearer) {
+    // No token at all — kick off the OAuth dance. beginLogin() never returns.
+    await beginLogin();
+  }
+  let res = await doFetch(path, init, bearer);
+  if (res.status === 401) {
+    const refreshed = await refreshAccessToken();
+    if (refreshed) {
+      bearer = refreshed;
+      res = await doFetch(path, init, bearer);
     }
-    throw new Error(message);
+    if (res.status === 401) {
+      // Refresh failed or post-refresh still 401 — drop tokens and re-auth.
+      clearTokens();
+      await beginLogin();
+    }
+  }
+  if (!res.ok) {
+    throw new Error(await readError(res));
   }
   if (res.status === 204) return undefined as T;
   return (await res.json()) as T;

--- a/web/ui/src/lib/auth.ts
+++ b/web/ui/src/lib/auth.ts
@@ -1,0 +1,266 @@
+/**
+ * OAuth 2.0 client for the Paraclaw web UI. The hub is the authorization
+ * server (parachute-patterns/patterns/hub-as-issuer.md):
+ *
+ *   1. GET  /api/discovery           — returns `{ hubOrigin }` so the bundle
+ *                                       doesn't bake the origin in.
+ *   2. POST <hub>/oauth/register      — RFC 7591 DCR; we cache the client_id
+ *                                       in localStorage keyed by hub origin.
+ *   3. GET  <hub>/oauth/authorize     — PKCE-S256, redirect-back.
+ *   4. <app>/oauth/callback           — code + state; we exchange for tokens.
+ *   5. POST <hub>/oauth/token         — authorization_code, then refresh_token
+ *                                       on 401 from /api/* before re-login.
+ *
+ * Scopes: `claw:write vault:read vault:write`. The vault scopes anticipate
+ * the vault tokens-API REST endpoint (paraclaw#4 companion vault issue);
+ * today the server still shells out, but minting the user JWT with vault:*
+ * now means no re-consent later.
+ */
+interface DiscoveryResponse {
+  hubOrigin: string;
+}
+
+interface ClientRecord {
+  client_id: string;
+}
+
+interface TokenSet {
+  access_token: string;
+  refresh_token: string;
+  expires_at: number; // epoch seconds
+}
+
+interface FlowState {
+  verifier: string;
+  state: string;
+  redirect_uri: string;
+  hub_origin: string;
+}
+
+const REQUESTED_SCOPES = "claw:write vault:read vault:write";
+const DISCOVERY_KEY = "paraclaw.discovery";
+const FLOW_KEY = "paraclaw.flow";
+
+function clientKey(hubOrigin: string): string {
+  return `paraclaw.client.${hubOrigin}`;
+}
+function tokensKey(hubOrigin: string): string {
+  return `paraclaw.tokens.${hubOrigin}`;
+}
+
+function readJson<T>(storage: Storage, key: string): T | null {
+  const raw = storage.getItem(key);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    storage.removeItem(key);
+    return null;
+  }
+}
+
+function writeJson(storage: Storage, key: string, value: unknown): void {
+  storage.setItem(key, JSON.stringify(value));
+}
+
+function getRedirectUri(): string {
+  // Vite's BASE_URL has a trailing slash (`/` or `/claw/`), so the join
+  // yields `http://host/oauth/callback` or `http://host/claw/oauth/callback`.
+  return `${window.location.origin}${import.meta.env.BASE_URL}oauth/callback`;
+}
+
+async function getDiscovery(): Promise<DiscoveryResponse> {
+  const cached = readJson<DiscoveryResponse>(localStorage, DISCOVERY_KEY);
+  if (cached) return cached;
+  // Fetch raw — discovery is unauthenticated, and routing it through the API
+  // wrapper would create a bootstrap dep cycle (api ↔ auth).
+  const res = await fetch("/api/discovery", { headers: { accept: "application/json" } });
+  if (!res.ok) throw new Error(`/api/discovery failed: ${res.status}`);
+  const fresh = (await res.json()) as DiscoveryResponse;
+  writeJson(localStorage, DISCOVERY_KEY, fresh);
+  return fresh;
+}
+
+async function ensureClient(hubOrigin: string): Promise<string> {
+  const cached = readJson<ClientRecord>(localStorage, clientKey(hubOrigin));
+  if (cached?.client_id) return cached.client_id;
+  const redirectUri = getRedirectUri();
+  const res = await fetch(`${hubOrigin}/oauth/register`, {
+    method: "POST",
+    headers: { "content-type": "application/json", accept: "application/json" },
+    body: JSON.stringify({
+      redirect_uris: [redirectUri],
+      scope: REQUESTED_SCOPES,
+      client_name: "Paraclaw web UI",
+      token_endpoint_auth_method: "none",
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`hub /oauth/register failed: ${res.status} ${await res.text()}`);
+  }
+  const body = (await res.json()) as { client_id: string };
+  writeJson(localStorage, clientKey(hubOrigin), { client_id: body.client_id });
+  return body.client_id;
+}
+
+function randomBytes(n: number): Uint8Array {
+  const out = new Uint8Array(n);
+  crypto.getRandomValues(out);
+  return out;
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let s = "";
+  for (const b of bytes) s += String.fromCharCode(b);
+  return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+async function sha256(input: string): Promise<Uint8Array> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
+  return new Uint8Array(digest);
+}
+
+async function makePkcePair(): Promise<{ verifier: string; challenge: string }> {
+  const verifier = base64UrlEncode(randomBytes(32));
+  const challenge = base64UrlEncode(await sha256(verifier));
+  return { verifier, challenge };
+}
+
+/** Kick off the OAuth dance. Top-level navigation; never returns. */
+export async function beginLogin(): Promise<never> {
+  const { hubOrigin } = await getDiscovery();
+  const clientId = await ensureClient(hubOrigin);
+  const { verifier, challenge } = await makePkcePair();
+  const state = base64UrlEncode(randomBytes(16));
+  const redirectUri = getRedirectUri();
+  const flow: FlowState = {
+    verifier,
+    state,
+    redirect_uri: redirectUri,
+    hub_origin: hubOrigin,
+  };
+  writeJson(sessionStorage, FLOW_KEY, flow);
+  const u = new URL(`${hubOrigin}/oauth/authorize`);
+  u.searchParams.set("client_id", clientId);
+  u.searchParams.set("redirect_uri", redirectUri);
+  u.searchParams.set("response_type", "code");
+  u.searchParams.set("scope", REQUESTED_SCOPES);
+  u.searchParams.set("code_challenge", challenge);
+  u.searchParams.set("code_challenge_method", "S256");
+  u.searchParams.set("state", state);
+  window.location.replace(u.toString());
+  // Block until navigation actually happens — callers expect this never
+  // returns control.
+  return new Promise<never>(() => {});
+}
+
+/**
+ * Exchange `code` for tokens. Throws on any failure (state mismatch, hub
+ * error, missing flow). Callers should catch + show the error and offer a
+ * retry that calls beginLogin().
+ */
+export async function handleCallback(params: URLSearchParams): Promise<void> {
+  const flow = readJson<FlowState>(sessionStorage, FLOW_KEY);
+  if (!flow) throw new Error("no in-flight OAuth flow — restart sign-in");
+  sessionStorage.removeItem(FLOW_KEY);
+  const err = params.get("error");
+  if (err) {
+    throw new Error(`hub returned OAuth error: ${err} — ${params.get("error_description") ?? ""}`);
+  }
+  const code = params.get("code");
+  const state = params.get("state");
+  if (!code || !state) throw new Error("hub callback missing code or state");
+  if (state !== flow.state) throw new Error("OAuth state mismatch — possible CSRF");
+  const clientId = readJson<ClientRecord>(localStorage, clientKey(flow.hub_origin))?.client_id;
+  if (!clientId) throw new Error("client registration missing — restart sign-in");
+  const tokens = await postToken(flow.hub_origin, {
+    grant_type: "authorization_code",
+    code,
+    client_id: clientId,
+    redirect_uri: flow.redirect_uri,
+    code_verifier: flow.verifier,
+  });
+  storeTokens(flow.hub_origin, tokens);
+}
+
+async function postToken(
+  hubOrigin: string,
+  form: Record<string, string>,
+): Promise<{ access_token: string; refresh_token: string; expires_in: number }> {
+  const body = new URLSearchParams();
+  for (const [k, v] of Object.entries(form)) body.set(k, v);
+  const res = await fetch(`${hubOrigin}/oauth/token`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      accept: "application/json",
+    },
+    body: body.toString(),
+  });
+  if (!res.ok) {
+    const txt = await res.text();
+    throw new Error(`hub /oauth/token failed: ${res.status} ${txt}`);
+  }
+  return (await res.json()) as { access_token: string; refresh_token: string; expires_in: number };
+}
+
+function storeTokens(
+  hubOrigin: string,
+  t: { access_token: string; refresh_token: string; expires_in: number },
+): void {
+  const expires_at = Math.floor(Date.now() / 1000) + t.expires_in;
+  const ts: TokenSet = {
+    access_token: t.access_token,
+    refresh_token: t.refresh_token,
+    expires_at,
+  };
+  writeJson(localStorage, tokensKey(hubOrigin), ts);
+}
+
+function readTokens(hubOrigin: string): TokenSet | null {
+  return readJson<TokenSet>(localStorage, tokensKey(hubOrigin));
+}
+
+/**
+ * Returns the current access token if we have one for the cached hub
+ * origin, regardless of expiry — the API wrapper handles 401-refresh. If
+ * we don't even have discovery yet, returns null (caller should prompt
+ * login).
+ */
+export function getAccessToken(): string | null {
+  const disc = readJson<DiscoveryResponse>(localStorage, DISCOVERY_KEY);
+  if (!disc) return null;
+  return readTokens(disc.hubOrigin)?.access_token ?? null;
+}
+
+/**
+ * Refresh the access token using the stored refresh token. Returns the
+ * new access token, or null if refresh isn't possible (no refresh, hub
+ * rejected). Caller should fall back to beginLogin() on null.
+ */
+export async function refreshAccessToken(): Promise<string | null> {
+  const disc = readJson<DiscoveryResponse>(localStorage, DISCOVERY_KEY);
+  if (!disc) return null;
+  const tokens = readTokens(disc.hubOrigin);
+  if (!tokens?.refresh_token) return null;
+  const clientId = readJson<ClientRecord>(localStorage, clientKey(disc.hubOrigin))?.client_id;
+  if (!clientId) return null;
+  try {
+    const fresh = await postToken(disc.hubOrigin, {
+      grant_type: "refresh_token",
+      refresh_token: tokens.refresh_token,
+      client_id: clientId,
+    });
+    storeTokens(disc.hubOrigin, fresh);
+    return fresh.access_token;
+  } catch {
+    return null;
+  }
+}
+
+/** Drop tokens; keeps discovery + client_id (DCR is one-shot per origin). */
+export function clearTokens(): void {
+  const disc = readJson<DiscoveryResponse>(localStorage, DISCOVERY_KEY);
+  if (!disc) return;
+  localStorage.removeItem(tokensKey(disc.hubOrigin));
+}

--- a/web/ui/src/routes/OAuthCallback.tsx
+++ b/web/ui/src/routes/OAuthCallback.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { beginLogin, handleCallback } from "../lib/auth.ts";
+
+/**
+ * Lands the redirect from the hub's /oauth/authorize. Exchanges `code` for
+ * tokens via /oauth/token, then bounces to `/`. On any failure (state
+ * mismatch, hub error, expired flow), shows the error and a retry that
+ * restarts the dance.
+ */
+export function OAuthCallback() {
+  const [params] = useSearchParams();
+  const navigate = useNavigate();
+  const [state, setState] = useState<
+    { kind: "exchanging" } | { kind: "error"; message: string }
+  >({ kind: "exchanging" });
+
+  useEffect(() => {
+    let cancelled = false;
+    handleCallback(params)
+      .then(() => {
+        if (!cancelled) navigate("/", { replace: true });
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setState({
+            kind: "error",
+            message: err instanceof Error ? err.message : String(err),
+          });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [params, navigate]);
+
+  if (state.kind === "exchanging") {
+    return (
+      <div className="empty">
+        <p>Signing you in&hellip;</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h2>Sign-in failed</h2>
+      <div className="error-banner">
+        <code>{state.message}</code>
+      </div>
+      <div className="actions" style={{ marginTop: "1rem" }}>
+        <button onClick={() => beginLogin()}>Try again</button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- The web UI server now requires a hub-issued JWT on every `/api/*` endpoint — operator-token (CLI/scripts) or user OAuth (browser). Two endpoints stay unauth: `/api/health` (probe) and `/api/discovery` (returns `{ hubOrigin }` so the SPA can bootstrap OAuth without baking the origin into the bundle).
- Introduces the `claw:*` scope vocabulary: `claw:read` ⊆ `claw:write` ⊆ `claw:admin`. `vault:admin` (operator-token shape) is the catch-all that satisfies every claw scope; `hub:admin` deliberately does NOT — admins of the identity surface aren't implicitly admins of every resource server.
- The browser SPA walks RFC 7591 DCR + PKCE-S256 against the hub on first load, caches `client_id` by hub origin in localStorage, and refreshes once on 401 before bouncing back to login. `/oauth/callback` is a new SPA route.

This is the security unlock for tailnet exposure: today loopback bind is load-bearing for safety; once auth lands, the same surface can be exposed via `tailscale serve` without changing the trust model.

## Implementation notes

- `web/server/src/auth.ts` mirrors `parachute-vault/src/hub-jwt.ts` deliberately — same trust model, same load-bearing checks (`iss` strict; `aud` parsed but not enforced). The shared scope-guard library proposed in cli#59 will eventually absorb both.
- Hub origin via `PARACLAW_HUB_ORIGIN` env, NOT `services.json` (matches vault's deliberate choice — the hub is the dispatcher, not a registered service).
- `WWW-Authenticate: Bearer` challenge on 401; `WWW-Authenticate: Bearer error="insufficient_scope", scope="<x>"` on 403, per RFC 6750.
- UI requests scopes `claw:write vault:read vault:write`. The vault scopes anticipate the vault tokens-API REST endpoint (companion issue, see below); today the server still shells out to `parachute vault tokens create`, but minting the user JWT with `vault:*` now means no re-consent later.

## Shell-out kept (option 1)

The attach-vault flow continues to spawn `parachute vault tokens create`. Switching to "use the user's JWT to call vault's REST" needs a hub-JWT-authenticated tokens-mint endpoint in vault that doesn't exist today. Companion issue will be filed in `parachute-vault` titled *"Add `POST /vault/<name>/tokens` REST endpoint for hub-JWT-authenticated token minting"*; once it lands, paraclaw flips one helper.

## Patterns

- `parachute-patterns/patterns/hub-as-issuer.md` — paraclaw is now a resource server in this model.
- `parachute-patterns/patterns/oauth-scopes.md` — `claw:*` introduced; `vault:admin` catch-all preserved across resource servers.
- `parachute-patterns/patterns/service-to-service-auth.md` — the JWKS-against-hub pattern.

## Versions

- `@paraclaw/web-server`: 0.0.4-rc.1 → 0.0.5-rc.1
- `@paraclaw/web-ui`: 0.0.4-rc.1 → 0.0.5-rc.1
- Adds `jose@6.2.2` to root deps.

## Test plan

- [x] `pnpm vitest run` — 219/219 passing (16 new cases in `web/server/src/auth.test.ts` covering happy path, wrong issuer, expired token, unpublished signing key, JWKS unreachable, scope inheritance, `vault:admin` catch-all, `hub:admin` denial, 401 missing/malformed/invalid header, 403 insufficient_scope with `error_type` + `required_scope` + `granted_scopes`).
- [x] `pnpm --filter @paraclaw/web-server typecheck`
- [x] `pnpm --filter @paraclaw/web-ui typecheck`
- [x] `pnpm --filter @paraclaw/web-ui build` — bundle 263 KB (gzip 82 KB).
- [ ] Manual: open the SPA in a browser → DCR + PKCE dance against a local hub → land on `/oauth/callback` → tokens stored → group list loads with Bearer header.
- [ ] Manual: `curl -H "Authorization: Bearer <operator-token>" /api/groups` returns the group list (operator-token has `vault:admin` so claw:read passes via catch-all).
- [ ] Manual: `curl /api/groups` (no header) returns 401 with `WWW-Authenticate: Bearer`.

## Out of scope (per brief)

- Multi-user (only one operator today).
- Audit log of who did what.
- Lifecycle controls (start/stop/restart agents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)