### PR TITLE
chore(manifest): startCmd uses bun + .ts source (refs #12, hub#83)

### DIFF
--- a/.parachute/module.json
+++ b/.parachute/module.json
@@ -7,7 +7,7 @@
   "port": 1944,
   "paths": ["/claw"],
   "health": "/api/health",
-  "startCmd": ["node", "web/server/dist/server.js"],
+  "startCmd": ["bun", "web/server/src/server.ts"],
   "scopes": {
     "defines": ["claw:read", "claw:write", "claw:admin"]
   }


### PR DESCRIPTION
Trims paraclaw#12 to what's safely shippable today; lifecycle wiring waits on parachute-hub#83.

## What changes

`.parachute/module.json` `startCmd`:
```diff
- ["node", "web/server/dist/server.js"]
+ ["bun", "web/server/src/server.ts"]
```

Bun handles `.ts` natively — no compile step needed. The previous shape was aspirational; paraclaw has no build pipeline producing `dist/` today.

## Why this is a no-behavior PR

`parachute start paraclaw` cannot work yet. `parachute-hub/src/service-spec.ts:412` (`getSpec`) only resolves names in `FIRST_PARTY_FALLBACKS`; third-party modules return undefined → `lifecycle.ts:138` errors out with `"unknown service paraclaw. known: vault, notes, scribe, channel"`. The composed-spec path at `install.ts:457` runs at install-time only, then the spec is discarded.

This is documented as a known follow-up at `service-spec.ts:405-411` (*"third-party modules installed via module.json don't get a runtime spec out of this lookup yet"*). [parachute-hub#83](https://github.com/ParachuteComputer/parachute-hub/issues/83) is the umbrella for adding it.

So today this PR is a future-proofing manifest tweak. The moment hub#83 ships option (B) — `installDir` in services.json + spawn with `cwd=installDir` — paraclaw lifecycle Just Works without further paraclaw changes.

## Verification done locally

Started paraclaw under `tsx web/server/src/server.ts` (= what `["bun", "web/server/src/server.ts"]` will resolve to under hub spawn) with `PARACHUTE_HOME=/tmp/test`:

- ✓ `module.json` validates against hub's strict `validateModuleManifest`
- ✓ Server boots, binds 127.0.0.1:11944
- ✓ services.json self-registration writes the canonical entry from PR #11:
  ```json
  { "name": "claw", "port": 11944, "paths": ["/claw"], "health": "/api/health",
    "version": "0.0.6-rc.1", "displayName": "Paraclaw", "tagline": "..." }
  ```
- ✓ `/api/health` returns `{service, version, data_dir, groups_dir}`
- ✓ Standalone `VITE_BASE_PATH=/` build serves `/` correctly with `/assets/...` references resolving to dist/

## Tailnet `/claw/` exposure — DOES NOT WORK YET

Built UI with `VITE_BASE_PATH=/claw/`, started server, hit the URLs:

| Request | Status | Content-Type | Note |
|---|---|---|---|
| `GET /` | 200 | text/html | index.html (refs `/claw/assets/...`) |
| `GET /claw/` | 200 | text/html | Same SPA shell (only because `dist/claw/` doesn't exist → SPA fallback) |
| `GET /claw/assets/index-X.js` | 200 | **text/html** | ⚠ Falls through to SPA shell — bundle never loads |

Root cause: `web/server/src/server.ts:472-506` (`serveStatic`) maps URL path 1:1 onto `dist/`. With `/claw/` baked into the bundle, `dist/claw/assets/...` doesn't exist and the fallback hands back `index.html` with `text/html`. The browser would parse the script tag, fetch the JS, get HTML, and the page never boots. Same failure mode under tailnet (tailscale serve preserves the `/claw` prefix when forwarding — see `parachute-hub/src/notes-serve.ts:14-20`).

Filed as [paraclaw#13](https://github.com/ParachuteComputer/paraclaw/issues/13). Fix mirrors the `--mount` strip pattern from `parachute-hub/src/notes-serve.ts:96-115`. ~80 LOC + tests; intentionally out of scope here.

## Other items from #12 brief

- **Local-path install via cli#56** — verifiable today only up to seed-write; auto-start would error \"unknown service\". Blocked on hub#83.
- **`parachute expose tailnet` discovery** — works today (path-routing reads services.json, doesn't need `getSpec`). Once paraclaw is in services.json the entry is picked up; only the static-serve mount-strip (#13) blocks asset loading after the proxy is up.
- **0.0.0.0 binding option** — not needed. tailscale serve goes tailnet → 127.0.0.1 (loopback), so localhost binding is fine. Confirmed by reading `parachute-hub/src/hub-server.ts`.

## RC bump

None — this is a no-behavior manifest edit. Versions stay at `0.0.6-rc.1` for both web/server and web/ui.

## Don't close #12

#12 stays open; PR #11 closed the manifest piece, this PR closes the startCmd shape, but the full \"manageable via the hub\" goal needs hub#83 + paraclaw#13 to land before #12 can close.

## Gates

- ✓ paraclaw web vitest: 20/20 passing
- ✓ web/server typecheck clean
- ✓ web/ui typecheck + build clean
- ✓ Manifest validates against hub `validateModuleManifest`