### PR TITLE
fix(web/server): strip mount prefix before resolving against dist/ (closes #13)

### DIFF
--- a/web/server/package.json
+++ b/web/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraclaw/web-server",
-  "version": "0.0.6-rc.1",
+  "version": "0.0.7-rc.1",
   "private": true,
   "description": "Paraclaw web UI server. Lists agent groups + manages vault attachments. Reuses NanoClaw's better-sqlite3 + Parachute attach helpers.",
   "license": "AGPL-3.0",

--- a/web/server/src/server.ts
+++ b/web/server/src/server.ts
@@ -58,6 +58,7 @@ import {
   type ClawScope,
 } from './auth.js';
 import { upsertService } from './services-manifest.js';
+import { makeServeStatic, normalizeMount } from './static-serve.js';
 
 const CENTRAL_DB_PATH = path.join(DATA_DIR, 'v2.db');
 
@@ -68,7 +69,13 @@ const UI_DIST = path.resolve(__dirname, '../../ui/dist');
 // via PARACLAW_WEB_PORT for tests / non-default deployments.
 const PORT = Number(process.env.PARACLAW_WEB_PORT ?? 1944);
 const HOST = process.env.PARACLAW_WEB_BIND ?? '127.0.0.1';
-const SERVICE_VERSION = '0.0.6-rc.1';
+// When fronted by `parachute expose tailnet` at a path prefix, set
+// PARACLAW_WEB_MOUNT to that prefix (e.g. `/claw`) so static-serve strips
+// it before resolving against dist/. The hub-managed lifecycle (once
+// parachute-hub#83 ships) will set this from `module.json` `paths[0]`
+// automatically. Empty string = serve at the origin root (default).
+const MOUNT = normalizeMount(process.env.PARACLAW_WEB_MOUNT ?? '');
+const SERVICE_VERSION = '0.0.7-rc.1';
 
 // NanoClaw's mutating helpers (createAgentGroup, etc.) talk to a
 // process-singleton DB connection (`getDb`). Initialize it once at boot so
@@ -458,52 +465,7 @@ async function handleApi(
 
 // --- Static file serving (built UI) -----------------------------------------
 
-const MIME_TYPES: Record<string, string> = {
-  '.html': 'text/html; charset=utf-8',
-  '.js': 'application/javascript; charset=utf-8',
-  '.css': 'text/css; charset=utf-8',
-  '.json': 'application/json; charset=utf-8',
-  '.svg': 'image/svg+xml',
-  '.png': 'image/png',
-  '.ico': 'image/x-icon',
-  '.txt': 'text/plain; charset=utf-8',
-};
-
-function serveStatic(req: http.IncomingMessage, res: http.ServerResponse, urlPath: string): void {
-  if (!fs.existsSync(UI_DIST)) {
-    res.writeHead(503, { 'content-type': 'text/plain; charset=utf-8' });
-    res.end(
-      'UI bundle not found at ' +
-        UI_DIST +
-        '\n\nIn dev: run `pnpm --filter @paraclaw/web-ui dev` and open http://localhost:5173/.\n' +
-        'In prod: run `pnpm --filter @paraclaw/web-ui build` first.',
-    );
-    return;
-  }
-
-  // Map / → index.html. Strip leading slash.
-  let rel = urlPath.replace(/^\/+/, '') || 'index.html';
-
-  // Path traversal guard.
-  if (rel.includes('..')) {
-    res.writeHead(400);
-    res.end('bad path');
-    return;
-  }
-
-  let abs = path.join(UI_DIST, rel);
-  // SPA fallback — any unknown route under root falls back to index.html so
-  // BrowserRouter routes resolve.
-  if (!fs.existsSync(abs)) {
-    abs = path.join(UI_DIST, 'index.html');
-    rel = 'index.html';
-  }
-  const ext = path.extname(abs).toLowerCase();
-  const mime = MIME_TYPES[ext] ?? 'application/octet-stream';
-  const stream = fs.createReadStream(abs);
-  res.writeHead(200, { 'content-type': mime });
-  stream.pipe(res);
-}
+const serveStatic = makeServeStatic({ distDir: UI_DIST, mount: MOUNT });
 
 // --- Server ------------------------------------------------------------------
 
@@ -536,6 +498,9 @@ server.listen(PORT, HOST, () => {
     console.log(`  ui:         serving from ${UI_DIST}`);
   } else {
     console.log(`  ui:         (not built — run pnpm --filter @paraclaw/web-ui build, or dev separately on :5173)`);
+  }
+  if (MOUNT) {
+    console.log(`  mount:      ${MOUNT} (PARACLAW_WEB_MOUNT — strips this prefix off static-serve requests)`);
   }
   // Self-register so `parachute status` + `parachute expose` see paraclaw.
   // Best-effort: a manifest write failure (perms / disk / race) doesn't

--- a/web/server/src/static-serve.test.ts
+++ b/web/server/src/static-serve.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Static-serve mount-strip tests. Mirrors the cases in paraclaw#13:
+ *   - mount=""  : behavior unchanged from pre-strip implementation
+ *   - mount=/X  : prefix stripped before resolving against dist/
+ *   - SPA fallback returns dist/index.html with text/html content-type
+ *   - Path traversal still 400s
+ *   - Absent dist/ → 503
+ *
+ * Uses a real http server bound to an ephemeral port + a real dist fixture
+ * on disk. Faster than spinning up the full paraclaw server (no DB / auth)
+ * but still exercises the actual fs + node http stack — same shape as
+ * auth.test.ts.
+ */
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { makeServeStatic, normalizeMount } from './static-serve.js';
+
+interface FetchResult {
+  status: number;
+  contentType: string;
+  body: string;
+}
+
+function fetchPath(baseUrl: string, urlPath: string): Promise<FetchResult> {
+  // Use http.request with explicit path so callers can send raw paths like
+  // `/../etc/passwd` without the URL parser normalizing `..` away before the
+  // request goes on the wire — that matters for the path-traversal test.
+  const url = new URL(baseUrl);
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: url.hostname,
+        port: url.port,
+        method: 'GET',
+        path: urlPath,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c) => chunks.push(c as Buffer));
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode ?? 0,
+            contentType: String(res.headers['content-type'] ?? ''),
+            body: Buffer.concat(chunks).toString('utf8'),
+          });
+        });
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+function startServer(handler: (req: http.IncomingMessage, res: http.ServerResponse) => void): Promise<{
+  server: http.Server;
+  baseUrl: string;
+}> {
+  return new Promise((resolve) => {
+    const server = http.createServer(handler);
+    server.listen(0, '127.0.0.1', () => {
+      const port = (server.address() as AddressInfo).port;
+      resolve({ server, baseUrl: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+function stopServer(server: http.Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+describe('normalizeMount', () => {
+  it('returns empty for empty + slash', () => {
+    expect(normalizeMount('')).toBe('');
+    expect(normalizeMount('/')).toBe('');
+  });
+
+  it('strips trailing slash', () => {
+    expect(normalizeMount('/claw')).toBe('/claw');
+    expect(normalizeMount('/claw/')).toBe('/claw');
+    expect(normalizeMount('/claw///')).toBe('/claw');
+  });
+});
+
+describe('makeServeStatic', () => {
+  let distDir: string;
+
+  beforeEach(() => {
+    distDir = mkdtempSync(join(tmpdir(), 'paraclaw-static-'));
+    writeFileSync(
+      join(distDir, 'index.html'),
+      '<!doctype html><html><body>shell</body></html>',
+    );
+    mkdirSync(join(distDir, 'assets'));
+    writeFileSync(join(distDir, 'assets', 'index-X.js'), 'export const k = 1;');
+    writeFileSync(join(distDir, 'assets', 'index-X.css'), 'body { color: red }');
+  });
+
+  afterEach(() => {
+    rmSync(distDir, { recursive: true, force: true });
+  });
+
+  describe('mount=""', () => {
+    let server: http.Server;
+    let baseUrl: string;
+
+    beforeAll(() => {});
+
+    beforeEach(async () => {
+      const handler = makeServeStatic({ distDir, mount: '' });
+      const ctx = await startServer((req, res) => {
+        const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
+        handler(req, res, url.pathname);
+      });
+      server = ctx.server;
+      baseUrl = ctx.baseUrl;
+    });
+
+    afterEach(async () => {
+      await stopServer(server);
+    });
+
+    it('GET / serves index.html as text/html', async () => {
+      const r = await fetchPath(baseUrl, '/');
+      expect(r.status).toBe(200);
+      expect(r.contentType).toContain('text/html');
+      expect(r.body).toContain('shell');
+    });
+
+    it('GET /assets/index-X.js serves the file as application/javascript', async () => {
+      const r = await fetchPath(baseUrl, '/assets/index-X.js');
+      expect(r.status).toBe(200);
+      expect(r.contentType).toContain('application/javascript');
+      expect(r.body).toBe('export const k = 1;');
+    });
+
+    it('GET /unknown/path SPA-falls-back to index.html', async () => {
+      const r = await fetchPath(baseUrl, '/unknown/path');
+      expect(r.status).toBe(200);
+      expect(r.contentType).toContain('text/html');
+      expect(r.body).toContain('shell');
+    });
+  });
+
+  describe('mount="/claw"', () => {
+    let server: http.Server;
+    let baseUrl: string;
+
+    beforeEach(async () => {
+      const handler = makeServeStatic({ distDir, mount: '/claw' });
+      const ctx = await startServer((req, res) => {
+        const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
+        handler(req, res, url.pathname);
+      });
+      server = ctx.server;
+      baseUrl = ctx.baseUrl;
+    });
+
+    afterEach(async () => {
+      await stopServer(server);
+    });
+
+    it('GET /claw/ serves index.html as text/html (prefix stripped → /)', async () => {
+      const r = await fetchPath(baseUrl, '/claw/');
+      expect(r.status).toBe(200);
+      expect(r.contentType).toContain('text/html');
+      expect(r.body).toContain('shell');
+    });
+
+    it('GET /claw/assets/index-X.js serves the JS bundle correctly (the regression #13 fixed)', async () => {
+      const r = await fetchPath(baseUrl, '/claw/assets/index-X.js');
+      expect(r.status).toBe(200);
+      expect(r.contentType).toContain('application/javascript');
+      expect(r.body).toBe('export const k = 1;');
+    });
+
+    it('GET /claw/assets/index-X.css serves CSS correctly', async () => {
+      const r = await fetchPath(baseUrl, '/claw/assets/index-X.css');
+      expect(r.status).toBe(200);
+      expect(r.contentType).toContain('text/css');
+      expect(r.body).toBe('body { color: red }');
+    });
+
+    it('GET /claw/some/spa/route SPA-falls-back to index.html (BrowserRouter resolves)', async () => {
+      const r = await fetchPath(baseUrl, '/claw/some/spa/route');
+      expect(r.status).toBe(200);
+      expect(r.contentType).toContain('text/html');
+      expect(r.body).toContain('shell');
+    });
+
+    it('GET /assets/index-X.js (no prefix) still serves the file — matches notes-serve behavior', async () => {
+      // Defense-in-depth: paths that don't start with the mount aren't 404'd.
+      // The real frontend never makes these requests (Vite bakes /claw/ into
+      // the bundle's asset URLs), but a direct test from a healthcheck or
+      // local-dev curl shouldn't break — same shape as
+      // parachute-hub/src/notes-serve.ts at paths-without-prefix.
+      const r = await fetchPath(baseUrl, '/assets/index-X.js');
+      expect(r.status).toBe(200);
+      expect(r.contentType).toContain('application/javascript');
+      expect(r.body).toBe('export const k = 1;');
+    });
+
+    it('GET /claw is a SPA route (no trailing slash) → SPA shell', async () => {
+      const r = await fetchPath(baseUrl, '/claw');
+      expect(r.status).toBe(200);
+      expect(r.contentType).toContain('text/html');
+      expect(r.body).toContain('shell');
+    });
+  });
+
+  describe('safety', () => {
+    // The URL constructor in server.ts (and in the http test fixture above)
+    // normalizes `..` away before the handler ever sees the path, so the
+    // `..` guard inside makeServeStatic is defense-in-depth — tested by
+    // calling the handler directly with a synthetic url-path.
+    it('handler called with a path containing `..` → 400 bad path', () => {
+      const handler = makeServeStatic({ distDir, mount: '' });
+      let status = 0;
+      let body = '';
+      const res = {
+        writeHead(s: number) {
+          status = s;
+        },
+        end(chunk?: string) {
+          body = chunk ?? '';
+        },
+      } as unknown as http.ServerResponse;
+      handler({} as http.IncomingMessage, res, '/../etc/passwd');
+      expect(status).toBe(400);
+      expect(body).toContain('bad path');
+    });
+  });
+
+  describe('missing dist', () => {
+    it('returns 503 with a build-instruction body', async () => {
+      const handler = makeServeStatic({
+        distDir: join(tmpdir(), 'paraclaw-does-not-exist-' + Date.now()),
+        mount: '',
+      });
+      const ctx = await startServer((req, res) => {
+        const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
+        handler(req, res, url.pathname);
+      });
+      try {
+        const r = await fetchPath(ctx.baseUrl, '/');
+        expect(r.status).toBe(503);
+        expect(r.body).toContain('UI bundle not found');
+      } finally {
+        await stopServer(ctx.server);
+      }
+    });
+  });
+});

--- a/web/server/src/static-serve.ts
+++ b/web/server/src/static-serve.ts
@@ -1,0 +1,107 @@
+/**
+ * Static-file handler for the built UI bundle, with optional mount-prefix
+ * stripping.
+ *
+ * When paraclaw is fronted by `parachute expose tailnet` at a path prefix
+ * (e.g. `https://<host>/claw/`), tailscale serve forwards the request with
+ * the prefix preserved. Combined with a Vite build that bakes the prefix
+ * into asset URLs (`VITE_BASE_PATH=/claw/`), the browser asks for
+ * `/claw/assets/index-X.js` — which a 1:1 path-to-dist map turns into the
+ * non-existent `dist/claw/assets/index-X.js`, falls back to the SPA shell,
+ * and ships `text/html` for what should be a JS module. Page never boots.
+ *
+ * Mirrors `parachute-hub/src/notes-serve.ts:96-115` — strip the mount
+ * prefix off the request path before resolving against `dist/`. Standalone
+ * paraclaw (`mount=""`) is unchanged: the strip is a no-op when no prefix
+ * is configured.
+ */
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const MIME_TYPES: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.ico': 'image/x-icon',
+  '.txt': 'text/plain; charset=utf-8',
+};
+
+/**
+ * Normalize a mount value to either `""` (no strip) or a prefix without a
+ * trailing slash (e.g. `/claw`). `""` and `"/"` both mean "no strip" so
+ * standalone deployments at the origin root don't accidentally strip a
+ * leading `/`.
+ */
+export function normalizeMount(raw: string): string {
+  if (raw === '' || raw === '/') return '';
+  return raw.replace(/\/+$/, '');
+}
+
+export interface StaticServeOpts {
+  distDir: string;
+  /** Mount prefix to strip before resolving against `distDir` (e.g. `/claw`). */
+  mount: string;
+}
+
+/**
+ * Build the static-serve handler closure. The returned function has the
+ * same shape as the inline handler that previously lived in server.ts —
+ * `(req, res, urlPath)` — but resolves through the configured mount + dist.
+ *
+ * SPA-fallback behavior matches the prior implementation: any path that
+ * doesn't resolve to a real file under `dist/` returns `index.html` so
+ * BrowserRouter routes work on hard-refresh. The mount-strip only changes
+ * the lookup; missing-file fallback is unchanged.
+ */
+export function makeServeStatic(opts: StaticServeOpts) {
+  const { distDir, mount } = opts;
+  return function serveStatic(
+    _req: http.IncomingMessage,
+    res: http.ServerResponse,
+    urlPath: string,
+  ): void {
+    if (!fs.existsSync(distDir)) {
+      res.writeHead(503, { 'content-type': 'text/plain; charset=utf-8' });
+      res.end(
+        'UI bundle not found at ' +
+          distDir +
+          '\n\nIn dev: run `pnpm --filter @paraclaw/web-ui dev` and open http://localhost:5173/.\n' +
+          'In prod: run `pnpm --filter @paraclaw/web-ui build` first.',
+      );
+      return;
+    }
+
+    let pathname = urlPath;
+    if (mount && (pathname === mount || pathname.startsWith(`${mount}/`))) {
+      pathname = pathname.slice(mount.length) || '/';
+    }
+
+    let rel = pathname.replace(/^\/+/, '') || 'index.html';
+
+    if (rel.includes('..')) {
+      res.writeHead(400);
+      res.end('bad path');
+      return;
+    }
+
+    let abs = path.join(distDir, rel);
+    if (!abs.startsWith(distDir)) {
+      res.writeHead(403);
+      res.end('forbidden');
+      return;
+    }
+
+    if (!fs.existsSync(abs) || !fs.statSync(abs).isFile()) {
+      abs = path.join(distDir, 'index.html');
+    }
+    const ext = path.extname(abs).toLowerCase();
+    const mime = MIME_TYPES[ext] ?? 'application/octet-stream';
+    const stream = fs.createReadStream(abs);
+    res.writeHead(200, { 'content-type': mime });
+    stream.pipe(res);
+  };
+}

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraclaw/web-ui",
-  "version": "0.0.6-rc.1",
+  "version": "0.0.7-rc.1",
   "private": true,
   "description": "Paraclaw web UI — Vite + React + TypeScript. Manages vault attachments per agent group.",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Summary

Fix the static-serve regression discovered during paraclaw#12 verification: when paraclaw is fronted by `parachute expose tailnet` at a path prefix (`/claw/`), the browser's request for `/claw/assets/index-X.js` gets 1:1-mapped to a non-existent `dist/claw/assets/index-X.js`, SPA-falls-back to `index.html`, and ships `text/html` for what should be a JS module. The page never boots.

Mirrors the proven pattern in `parachute-hub/src/notes-serve.ts:96-115` — strip the configured mount prefix off the request path before resolving against `dist/`. Independent of parachute-hub#83 (third-party module lifecycle), can ship in parallel.

- **New module** `web/server/src/static-serve.ts` exports `makeServeStatic` factory + `normalizeMount` helper. Replaces ~50 lines of inline static handling in `server.ts`. Path-traversal guard (`..`) and dist-escape guard (`!abs.startsWith(distDir)`) preserved + tightened (`isFile()` check for directory entries).
- **New env** `PARACLAW_WEB_MOUNT` — defaults to `""` (no strip; standalone deployments at the origin root are unchanged). Hub-managed lifecycle (parachute-hub#83) will set this from `module.json` `paths[0]` automatically.
- **13-case vitest suite** in `static-serve.test.ts`. Uses a real `http.Server` bound to an ephemeral port + tmpdir fixture for `dist/` — same shape as `auth.test.ts`, no DB / auth setup. Critical case: `GET /claw/assets/index-X.js → 200 application/javascript` (the regression #13 fixed).
- **Match notes' fallback behavior**: paths that don't start with the mount aren't 404'd. The real frontend never makes those requests (Vite bakes `/claw/` into asset URLs), but a healthcheck or local-dev curl shouldn't break.
- **RC bump** `0.0.6-rc.1 → 0.0.7-rc.1` on both `web/server` and `web/ui` packages.

The underlying convention is `mount-path-convention.md` in `parachute-patterns/` — paraclaw is the second module to need this strip after notes; the next one shouldn't have to rediscover it.

## Test plan

- [x] `pnpm --filter @paraclaw/web-server typecheck` — passes
- [x] `pnpm vitest run` (web/server) — 33/33 pass (13 new + 20 pre-existing)
- [x] `pnpm --filter @paraclaw/web-ui build` — clean (no UI changes; sanity)
- [x] **End-to-end mount-strip smoke**: built UI with `VITE_BASE_PATH=/claw/`, ran `PARACLAW_WEB_MOUNT=/claw pnpm web` on port 11944, observed:
  - `/claw/` → `200 text/html` (SPA shell, expected)
  - `/claw/assets/index-4h91PjIf.js` → **`200 application/javascript`** (the fix; was `200 text/html` before)
  - `/claw/some/spa/route` → `200 text/html` (SPA fallback, expected)
  - `/api/health` → `200 application/json` (API path unaffected by mount logic)
- [ ] When `parachute-hub#83` lands: end-to-end via `parachute expose tailnet` against the live tailnet hostname.

## References

- paraclaw#13 — this issue
- paraclaw#12 — discovered during verification of that PR's tailnet shape
- parachute-hub#83 — third-party module lifecycle (will auto-set `PARACLAW_WEB_MOUNT`)
- `parachute-hub/src/notes-serve.ts:96-115` — reference implementation
- `parachute-patterns/patterns/mount-path-convention.md` — the underlying pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)