### PR TITLE
fix(manifest): startCmd uses pnpm exec tsx instead of bun (better-sqlite3 incompatibility)

### DIFF
--- a/.parachute/module.json
+++ b/.parachute/module.json
@@ -7,7 +7,7 @@
   "port": 1944,
   "paths": ["/claw"],
   "health": "/api/health",
-  "startCmd": ["bun", "web/server/src/server.ts"],
+  "startCmd": ["pnpm", "exec", "tsx", "web/server/src/server.ts"],
   "scopes": {
     "defines": ["claw:read", "claw:write", "claw:admin"]
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,7 @@ The agent container runs on **Bun**; the host runs on **Node** (pnpm). They comm
 - **Adding a Node CLI the agent invokes at runtime** (like `agent-browser`, `claude-code`, `vercel`) → put it in the Dockerfile's pnpm global-install block, pinned to an exact version via a new `ARG`. Don't use `bun install -g` — that bypasses the pnpm supply-chain policy.
 - **Changing the Dockerfile entrypoint or the dynamic-spawn command** (`src/container-runner.ts` line ~301) → keep `exec bun ...` so signals forward cleanly. The image has no `/app/dist`; don't reintroduce a tsc build step.
 - **Changing session-DB pragmas** (`container/agent-runner/src/db/connection.ts`) → `journal_mode=DELETE` is load-bearing for cross-mount visibility. Read the comment block at the top of the file first.
+- **Editing `.parachute/module.json` `startCmd`** → use `["pnpm", "exec", "tsx", "web/server/src/server.ts"]`, NOT `bun`. The web server reuses NanoClaw's `initDb()` which loads `better-sqlite3` (native bindings) — bun crashes on import. Host-runs-on-Node applies to the parachute lifecycle spawn too.
 
 ## CJK font support
 

--- a/web/server/package.json
+++ b/web/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraclaw/web-server",
-  "version": "0.0.7-rc.1",
+  "version": "0.0.8-rc.1",
   "private": true,
   "description": "Paraclaw web UI server. Lists agent groups + manages vault attachments. Reuses NanoClaw's better-sqlite3 + Parachute attach helpers.",
   "license": "AGPL-3.0",

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraclaw/web-ui",
-  "version": "0.0.7-rc.1",
+  "version": "0.0.8-rc.1",
   "private": true,
   "description": "Paraclaw web UI — Vite + React + TypeScript. Manages vault attachments per agent group.",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Smoke tested

End-to-end via `parachute install` + auto-start on Aaron's bun-linked checkout. Smoke ran on the stacked branch `fix/services-manifest-merge-upsert` (which includes this PR + #17), since the two fixes are joined links in the lifecycle chain.

```
$ kill $(lsof -ti tcp:1944) 2>/dev/null; rm -f ~/.parachute/claw/.env
$ parachute install ~/ParachuteComputer/paraclaw
  ✓ claw registered on port 1944
  ✓ claw started (pid 75357)            ← previously crashed at this step on bun + better-sqlite3

$ tail ~/.parachute/claw/logs/claw.log
  paraclaw-web listening on http://127.0.0.1:1944
  data_dir:   /Users/parachute/ParachuteComputer/paraclaw/data
  ui:         serving from /Users/parachute/ParachuteComputer/paraclaw/web/ui/dist

$ curl -sw "%{http_code} %{content_type}\n" http://127.0.0.1:1944/api/health
  200 application/json
```

Pre-fix log on the same branch with `["bun", ...]`:
```
FATAL Uncaught exception: 'better-sqlite3' is not yet supported in Bun.
  at initDb (paraclaw/src/db/connection.ts:16:13)
```

Process boots cleanly under tsx; no better-sqlite3 crash; lifecycle picks the service up; health probe is 200. Full smoke including the stop/start round-trip is documented in #17.

---

## Summary

PR #14's `["bun", "web/server/src/server.ts"]` startCmd crashes immediately in production. The web server reuses NanoClaw's `initDb()` which loads **`better-sqlite3`** (native Node bindings), and bun doesn't yet support that package:

```
FATAL Uncaught exception: 'better-sqlite3' is not yet supported in Bun.
Track the status in https://github.com/oven-sh/bun/issues/4290
  at initDb (paraclaw/src/db/connection.ts:16:13)
```

CLAUDE.md already documents the split — _"the agent container runs on **Bun**; the host runs on **Node** (pnpm)"_ — but `.parachute/module.json` is the surface the parachute lifecycle spawner reads, and it had drifted to bun. This restores host-runs-on-Node for the parachute spawn too.

## Changes

- `.parachute/module.json` — `startCmd` now `["pnpm", "exec", "tsx", "web/server/src/server.ts"]`. Same shape `pnpm dev` already uses; resolves cleanly when the lifecycle spawner cd's into installDir (which IS a pnpm workspace, so `pnpm exec` finds tsx in the content-addressed store from the package root without needing `node_modules/.bin/`).
- `CLAUDE.md` — adds one bullet next to the existing "Container Runtime (Bun)" section, so future editors of `.parachute/module.json` don't re-introduce bun for the lifecycle entrypoint.
- RC bump `0.0.7-rc.1 → 0.0.8-rc.1` on both `web/server` and `web/ui`. One-line manifest change but a real behavior fix; not a no-op edit.

## Test plan

- [x] `pnpm exec tsx web/server/src/server.ts` from the paraclaw root → boots, initializes the DB, binds 1944, serves `/api/health → 200 application/json`. (Same shape the lifecycle spawner runs after cd'ing into installDir.)
- [x] `bun web/server/src/server.ts` → reproduces the fatal `'better-sqlite3' is not yet supported in Bun` crash from the bug report.
- [x] Manifest validates against the hub's `validateModuleManifest` (no schema regression).
- [x] `pnpm typecheck` (web/server) — clean.
- [x] `pnpm vitest run` (web/server) — 33/33 pass (no test changes; sanity).
- [x] **End-to-end via `parachute install ~/ParachuteComputer/paraclaw`** — see Smoke tested section above.

## References

- paraclaw#14 — the PR that introduced the bun startCmd
- paraclaw#12 — full lifecycle integration (still open; this is one of the pieces)
- parachute-hub#83 — third-party module lifecycle (sets `PARACLAW_WEB_MOUNT` from manifest paths)
- `docs/build-and-runtime.md` — the host/container runtime split that should have caught this earlier

🤖 Generated with [Claude Code](https://claude.com/claude-code)