### PR TITLE
fix(web/server): strip mount before /api dispatch + read PARACHUTE_HUB_ORIGIN (closes #18)

### DIFF
--- a/web/server/package.json
+++ b/web/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraclaw/web-server",
-  "version": "0.0.9-rc.1",
+  "version": "0.0.10-rc.1",
   "private": true,
   "description": "Paraclaw web UI server. Lists agent groups + manages vault attachments. Reuses NanoClaw's better-sqlite3 + Parachute attach helpers.",
   "license": "AGPL-3.0",

--- a/web/server/package.json
+++ b/web/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraclaw/web-server",
-  "version": "0.0.8-rc.1",
+  "version": "0.0.9-rc.1",
   "private": true,
   "description": "Paraclaw web UI server. Lists agent groups + manages vault attachments. Reuses NanoClaw's better-sqlite3 + Parachute attach helpers.",
   "license": "AGPL-3.0",

--- a/web/server/src/auth.test.ts
+++ b/web/server/src/auth.test.ts
@@ -13,6 +13,7 @@ import { exportJWK, generateKeyPair, SignJWT } from 'jose';
 
 import {
   authenticate,
+  getHubOrigin,
   hasScope,
   HubJwtError,
   resetJwksCache,
@@ -177,6 +178,52 @@ describe('validateHubJwt', () => {
     fixture.setUnreachable(true);
     const token = await signJwt(kp, { iss: fixture.origin });
     await expect(validateHubJwt(token)).rejects.toBeInstanceOf(HubJwtError);
+  });
+});
+
+describe('getHubOrigin', () => {
+  // The hub lifecycle (parachute-hub/src/commands/lifecycle.ts) stamps
+  // PARACHUTE_HUB_ORIGIN onto every spawned service so iss-strict JWT
+  // validation works behind tailnet proxying. PARACLAW_HUB_ORIGIN is the
+  // test/per-service override. Loopback fallback exists for local-dev when
+  // the hub isn't supervising the process.
+  let prevParaclaw: string | undefined;
+  let prevParachute: string | undefined;
+
+  beforeEach(() => {
+    prevParaclaw = process.env.PARACLAW_HUB_ORIGIN;
+    prevParachute = process.env.PARACHUTE_HUB_ORIGIN;
+    delete process.env.PARACLAW_HUB_ORIGIN;
+    delete process.env.PARACHUTE_HUB_ORIGIN;
+  });
+
+  afterEach(() => {
+    if (prevParaclaw === undefined) delete process.env.PARACLAW_HUB_ORIGIN;
+    else process.env.PARACLAW_HUB_ORIGIN = prevParaclaw;
+    if (prevParachute === undefined) delete process.env.PARACHUTE_HUB_ORIGIN;
+    else process.env.PARACHUTE_HUB_ORIGIN = prevParachute;
+  });
+
+  it('reads PARACHUTE_HUB_ORIGIN as primary (set by hub lifecycle)', () => {
+    process.env.PARACHUTE_HUB_ORIGIN = 'https://parachute.taildf9ce2.ts.net';
+    expect(getHubOrigin()).toBe('https://parachute.taildf9ce2.ts.net');
+  });
+
+  it('PARACLAW_HUB_ORIGIN overrides PARACHUTE_HUB_ORIGIN', () => {
+    process.env.PARACHUTE_HUB_ORIGIN = 'https://parachute.taildf9ce2.ts.net';
+    process.env.PARACLAW_HUB_ORIGIN = 'http://localhost:9999';
+    expect(getHubOrigin()).toBe('http://localhost:9999');
+  });
+
+  it('falls back to loopback when neither env is set', () => {
+    expect(getHubOrigin()).toBe('http://127.0.0.1:1939');
+  });
+
+  it('strips trailing slash from either env', () => {
+    process.env.PARACHUTE_HUB_ORIGIN = 'https://hub.example/';
+    expect(getHubOrigin()).toBe('https://hub.example');
+    process.env.PARACLAW_HUB_ORIGIN = 'https://override.example/';
+    expect(getHubOrigin()).toBe('https://override.example');
   });
 });
 

--- a/web/server/src/auth.ts
+++ b/web/server/src/auth.ts
@@ -7,10 +7,13 @@
  * The shared scope-guard library proposed in cli#59 will eventually absorb
  * both.
  *
- * Hub origin resolution: `PARACLAW_HUB_ORIGIN` env override → loopback
- * `http://127.0.0.1:1939`. We intentionally do NOT read services.json — the
- * hub is the dispatcher, not a registered service in that file (matching
- * vault's choice).
+ * Hub origin resolution: `PARACLAW_HUB_ORIGIN` (test override) →
+ * `PARACHUTE_HUB_ORIGIN` (the hub lifecycle stamps this on every spawned
+ * service — see `parachute-hub/src/commands/lifecycle.ts`) → loopback
+ * `http://127.0.0.1:1939`. We intentionally do NOT read services.json —
+ * the hub is the dispatcher, not a registered service in that file
+ * (matching vault's choice). Tailnet-served paraclaw must see the hub's
+ * tailnet origin or `iss` mismatch rejects every JWT.
  *
  * Scope vocabulary introduced here: `claw:read` / `claw:write` / `claw:admin`
  * with `admin ⊇ write ⊇ read` inheritance per
@@ -34,8 +37,10 @@ export type ClawScope =
   | typeof SCOPE_CLAW_ADMIN;
 
 export function getHubOrigin(): string {
-  const env = process.env.PARACLAW_HUB_ORIGIN?.replace(/\/$/, '');
-  if (env && env.length > 0) return env;
+  const override = process.env.PARACLAW_HUB_ORIGIN?.replace(/\/$/, '');
+  if (override && override.length > 0) return override;
+  const fromHub = process.env.PARACHUTE_HUB_ORIGIN?.replace(/\/$/, '');
+  if (fromHub && fromHub.length > 0) return fromHub;
   return DEFAULT_HUB_LOOPBACK;
 }
 

--- a/web/server/src/server.ts
+++ b/web/server/src/server.ts
@@ -75,7 +75,7 @@ const HOST = process.env.PARACLAW_WEB_BIND ?? '127.0.0.1';
 // parachute-hub#83 ships) will set this from `module.json` `paths[0]`
 // automatically. Empty string = serve at the origin root (default).
 const MOUNT = normalizeMount(process.env.PARACLAW_WEB_MOUNT ?? '');
-const SERVICE_VERSION = '0.0.7-rc.1';
+const SERVICE_VERSION = '0.0.10-rc.1';
 
 // NanoClaw's mutating helpers (createAgentGroup, etc.) talk to a
 // process-singleton DB connection (`getDb`). Initialize it once at boot so
@@ -244,8 +244,8 @@ async function handleApi(
   req: http.IncomingMessage,
   res: http.ServerResponse,
   url: URL,
+  pathname: string = url.pathname,
 ): Promise<void> {
-  const { pathname } = url;
   const method = req.method ?? 'GET';
 
   // Unauthenticated probes: liveness check and OAuth-bootstrap discovery.
@@ -472,8 +472,19 @@ const serveStatic = makeServeStatic({ distDir: UI_DIST, mount: MOUNT });
 const server = http.createServer(async (req, res) => {
   try {
     const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
-    if (url.pathname.startsWith('/api/')) {
-      await handleApi(req, res, url);
+    // Strip MOUNT (e.g. `/claw`) once, here, before dispatch — Tailscale
+    // serve / the hub's reverse proxy preserve the prefix when forwarding.
+    // Without this, `/claw/api/health` falls through `/api/`-startsWith
+    // and gets SPA-shelled as text/html. (parachute-hub/src/notes-serve.ts
+    // does the same dance for the notes PWA.) Static-serve does its own
+    // internal strip via makeServeStatic, but routing through one
+    // canonical strip keeps the two surfaces consistent.
+    const dispatchPath =
+      MOUNT && (url.pathname === MOUNT || url.pathname.startsWith(`${MOUNT}/`))
+        ? url.pathname.slice(MOUNT.length) || '/'
+        : url.pathname;
+    if (dispatchPath.startsWith('/api/')) {
+      await handleApi(req, res, url, dispatchPath);
       return;
     }
     if (req.method === 'GET' || req.method === 'HEAD') {

--- a/web/server/src/services-manifest.test.ts
+++ b/web/server/src/services-manifest.test.ts
@@ -84,6 +84,45 @@ describe('upsertService', () => {
     expect(raw.services.map((s) => s.name).sort()).toEqual(['claw', 'vault']);
   });
 
+  it('preserves hub-stamped fields on the row (e.g. installDir from parachute-hub#84)', () => {
+    // The hub stamps `installDir` onto the row at install time. Paraclaw's
+    // self-registration row shape doesn't know about that field, but the
+    // upsert must merge rather than replace so the hub-stamped value
+    // survives the second write — otherwise `parachute start claw` after
+    // an auto-start round-trip can't resolve installDir → "unknown service".
+    writeFileSync(
+      path,
+      JSON.stringify({
+        services: [
+          {
+            name: 'claw',
+            port: 1944,
+            paths: ['/claw'],
+            health: '/api/health',
+            version: '0.0.7-rc.1',
+            installDir: '/Users/test/.parachute/claw',
+          },
+        ],
+      }),
+    );
+    upsertService(
+      {
+        name: 'claw',
+        port: 1944,
+        paths: ['/claw'],
+        health: '/api/health',
+        version: '0.0.8-rc.1',
+      },
+      path,
+    );
+    const raw = JSON.parse(readFileSync(path, 'utf8')) as {
+      services: { version: string; installDir?: string }[];
+    };
+    expect(raw.services).toHaveLength(1);
+    expect(raw.services[0].version).toBe('0.0.8-rc.1');
+    expect(raw.services[0].installDir).toBe('/Users/test/.parachute/claw');
+  });
+
   it('throws on a malformed existing manifest (so we never silently overwrite)', () => {
     writeFileSync(path, '{"services": "not an array"}');
     expect(() =>

--- a/web/server/src/services-manifest.ts
+++ b/web/server/src/services-manifest.ts
@@ -49,7 +49,11 @@ export function upsertService(entry: ServiceEntry, path: string = resolveManifes
   mkdirSync(dirname(path), { recursive: true });
   const manifest = readManifest(path);
   const idx = manifest.services.findIndex((s) => s.name === entry.name);
-  if (idx >= 0) manifest.services[idx] = entry;
+  // Merge rather than replace so fields the hub stamps onto the row
+  // (`installDir` from parachute-hub#84, etc.) survive a self-registration
+  // pass. Paraclaw still wins for the fields it owns — port, paths,
+  // version, health — because they spread last.
+  if (idx >= 0) manifest.services[idx] = { ...manifest.services[idx], ...entry };
   else manifest.services.push(entry);
   const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
   writeFileSync(tmp, `${JSON.stringify(manifest, null, 2)}\n`);

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraclaw/web-ui",
-  "version": "0.0.9-rc.1",
+  "version": "0.0.10-rc.1",
   "private": true,
   "description": "Paraclaw web UI — Vite + React + TypeScript. Manages vault attachments per agent group.",
   "license": "AGPL-3.0",

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraclaw/web-ui",
-  "version": "0.0.8-rc.1",
+  "version": "0.0.9-rc.1",
   "private": true,
   "description": "Paraclaw web UI — Vite + React + TypeScript. Manages vault attachments per agent group.",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Smoke tested

End-to-end via the actual tailnet path Aaron's browser hits — `parachute restart claw` (after stopping orphaned PIDs from prior runs), then curl through `https://parachute.taildf9ce2.ts.net/`. Hub stamps `PARACHUTE_HUB_ORIGIN=https://parachute.taildf9ce2.ts.net` on spawn (visible in the start log), so the running paraclaw sees the tailnet origin via the new env-var path.

\`\`\`
$ parachute start claw
✓ claw started (pid 77189); logs: /Users/parachute/.parachute/claw/logs/claw.log
  PARACHUTE_HUB_ORIGIN=https://parachute.taildf9ce2.ts.net

$ curl -sS -i https://parachute.taildf9ce2.ts.net/claw/api/health | head
HTTP/2 200
content-type: application/json

{"service":"paraclaw-web-server","version":"0.0.10-rc.1",...}        # ← was text/html SPA shell pre-fix

$ curl -sS https://parachute.taildf9ce2.ts.net/claw/api/discovery
{"hubOrigin":"https://parachute.taildf9ce2.ts.net"}                  # ← was loopback pre-fix

$ curl -sS -i https://parachute.taildf9ce2.ts.net/claw/api/groups | head
HTTP/2 401
content-type: application/json
www-authenticate: Bearer
{"error":"missing or malformed Authorization header"}                # ← auth route hit, not SPA-shelled

$ curl -sS -i https://parachute.taildf9ce2.ts.net/claw/api/nonexistent | head
HTTP/2 404
content-type: application/json
{"error":"not found: /api/nonexistent"}                              # ← MOUNT stripped before dispatch

$ curl -sS -i https://parachute.taildf9ce2.ts.net/claw/ | head -3
HTTP/2 200
content-type: text/html; charset=utf-8                               # ← SPA shell still served

$ curl -sS -i https://parachute.taildf9ce2.ts.net/claw/assets/index-4h91PjIf.js | head -3
HTTP/2 200
content-type: application/javascript; charset=utf-8                  # ← static assets still typed correctly
\`\`\`

Authenticated end-to-end with a fresh operator token + browser OAuth dance is for Aaron to do interactively (no hub user / operator token currently provisioned on this machine). Token-validation pipeline is verified to reach JWKS lookup against the tailnet origin (a stale token presented to \`/claw/api/groups\` was rejected with \`no applicable key found in the JSON Web Key Set\` — *not* an iss-mismatch error, which is what the pre-fix path would return).

## Summary

Two server-side bugs blocking paraclaw end-to-end on tailnet:

1. **API mount-strip** — \`server.ts\` dispatch checked \`url.pathname.startsWith('/api/')\` directly, so \`/claw/api/...\` (the path Tailscale serve / hub proxy forward when paraclaw is mounted under \`/claw\`) fell through to static-serve and got SPA-shelled as \`text/html\`. Apply MOUNT-strip uniformly *before* dispatch — same dance \`parachute-hub/src/notes-serve.ts\` does for the notes PWA. Static-serve still does its own internal strip via \`makeServeStatic\`; routing through one canonical strip keeps the two surfaces consistent. \`handleApi\` now takes the stripped pathname as an optional 4th arg (defaults to \`url.pathname\` so call-sites that don't go through a mount stay unchanged).

2. **Env var name** — \`auth.ts:getHubOrigin\` read \`PARACLAW_HUB_ORIGIN\`. The hub's lifecycle stamps \`PARACHUTE_HUB_ORIGIN\` on every spawned service (vault uses the same convention via \`hub-jwt.ts\`). Behind tailnet proxying, paraclaw never saw the tailnet origin → fell back to loopback → JWT \`iss\`-mismatch rejected every authenticated call. Read \`PARACHUTE_HUB_ORIGIN\` as primary; keep \`PARACLAW_HUB_ORIGIN\` as a per-service test override.

RC bump 0.0.9-rc.1 → 0.0.10-rc.1 (\`web/server\` + \`web/ui\`); SERVICE_VERSION constant in \`server.ts\` bumped to match.

## Stacking

Stacked on \`fix/services-manifest-merge-upsert\` (#17), which itself stacks on \`chore/startcmd-bun-runtime\` (#16). Merge order: #16 → #17 → #18, retargeting at each step. Once #16 lands, this PR's base will need to bump to \`fix/services-manifest-merge-upsert\` (still); once #17 lands, retarget this to \`main\`.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` — 241 passed (added 4 new \`getHubOrigin\` cases covering primary / override / loopback / trailing-slash)
- [x] Smoke test end-to-end via tailnet (see top of PR body)
- [ ] Browser OAuth dance + groups list load — Aaron interactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)