### PR TITLE
fix(ui): make API_BASE + discovery URL mount-aware (closes browser-side 404 on tailnet)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,22 @@ The agent container runs on **Bun**; the host runs on **Node** (pnpm). They comm
 - **Changing session-DB pragmas** (`container/agent-runner/src/db/connection.ts`) → `journal_mode=DELETE` is load-bearing for cross-mount visibility. Read the comment block at the top of the file first.
 - **Editing `.parachute/module.json` `startCmd`** → use `["pnpm", "exec", "tsx", "web/server/src/server.ts"]`, NOT `bun`. The web server reuses NanoClaw's `initDb()` which loads `better-sqlite3` (native bindings) — bun crashes on import. Host-runs-on-Node applies to the parachute lifecycle spawn too.
 
+## Web UI (mount-aware)
+
+The paraclaw SPA in `web/ui/` is served at the origin root in dev (`/`) and under a mount prefix in prod (`/claw/` when running behind the parachute hub on tailnet). The hub owns `/`; an absolute `/api/...` from the browser goes to the hub origin, NOT paraclaw — and the hub 404s on it. Anything the bundle sends to paraclaw must include the mount prefix.
+
+**Rule:** every URL the UI builds for `fetch`, router basenames, or OAuth redirects must be derived from `import.meta.env.BASE_URL`, not hardcoded with a leading `/`. Same bundle has to work whether the deploy lands at `/`, `/claw/`, or `/some/other/mount/`.
+
+Pattern (BASE_URL has a trailing slash; trim it for joining):
+
+```ts
+const API_BASE = `${import.meta.env.BASE_URL.replace(/\/$/, "")}/api`;
+const cb       = `${window.location.origin}${import.meta.env.BASE_URL}oauth/callback`;
+<BrowserRouter basename={import.meta.env.BASE_URL.replace(/\/$/, "")}>
+```
+
+The server-side mirror lives in `web/server/src/server.ts`: `MOUNT` (from `PARACLAW_WEB_MOUNT`) is stripped uniformly before dispatch so `/api/*` and static-serve both see paths without the prefix.
+
 ## CJK font support
 
 Agent containers ship without CJK fonts by default (~200MB saved). If you notice signals the user works with Chinese/Japanese/Korean content — conversing in CJK, CJK timezone (e.g., `Asia/Tokyo`, `Asia/Shanghai`, `Asia/Seoul`, `Asia/Taipei`, `Asia/Hong_Kong`), system locale hint, or mentions of needing to render CJK in screenshots/PDFs/scraped pages — offer to enable it:

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraclaw/web-ui",
-  "version": "0.0.11-rc.1",
+  "version": "0.0.12-rc.1",
   "private": true,
   "description": "Paraclaw web UI — Vite + React + TypeScript. Manages vault attachments per agent group.",
   "license": "AGPL-3.0",

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraclaw/web-ui",
-  "version": "0.0.10-rc.1",
+  "version": "0.0.11-rc.1",
   "private": true,
   "description": "Paraclaw web UI — Vite + React + TypeScript. Manages vault attachments per agent group.",
   "license": "AGPL-3.0",

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -11,7 +11,11 @@
  */
 import { beginLogin, clearTokens, getAccessToken, refreshAccessToken } from "./auth.ts";
 
-const API_BASE = "/api";
+// Mount-aware: when paraclaw is served at /claw/ (under hub on tailnet), API
+// calls must go to /claw/api/* — the bare /api/* path goes to the hub origin's
+// root, where it 404s. BASE_URL has the trailing slash already; the trim keeps
+// us from emitting //api when BASE_URL is /.
+const API_BASE = `${import.meta.env.BASE_URL.replace(/\/$/, "")}/api`;
 
 export type VaultScope = "vault:read" | "vault:write" | "vault:admin";
 

--- a/web/ui/src/lib/auth.ts
+++ b/web/ui/src/lib/auth.ts
@@ -73,9 +73,12 @@ async function getDiscovery(): Promise<DiscoveryResponse> {
   const cached = readJson<DiscoveryResponse>(localStorage, DISCOVERY_KEY);
   if (cached) return cached;
   // Fetch raw — discovery is unauthenticated, and routing it through the API
-  // wrapper would create a bootstrap dep cycle (api ↔ auth).
-  const res = await fetch("/api/discovery", { headers: { accept: "application/json" } });
-  if (!res.ok) throw new Error(`/api/discovery failed: ${res.status}`);
+  // wrapper would create a bootstrap dep cycle (api ↔ auth). Mount-aware:
+  // BASE_URL prepended so the request hits paraclaw under /claw/ on tailnet
+  // rather than the hub origin's root (which 404s on /api/discovery).
+  const url = `${import.meta.env.BASE_URL.replace(/\/$/, "")}/api/discovery`;
+  const res = await fetch(url, { headers: { accept: "application/json" } });
+  if (!res.ok) throw new Error(`${url} failed: ${res.status}`);
   const fresh = (await res.json()) as DiscoveryResponse;
   writeJson(localStorage, DISCOVERY_KEY, fresh);
   return fresh;

--- a/web/ui/src/main.tsx
+++ b/web/ui/src/main.tsx
@@ -9,7 +9,7 @@ if (!root) throw new Error("#root not found");
 
 createRoot(root).render(
   <StrictMode>
-    <BrowserRouter basename={import.meta.env.BASE_URL}>
+    <BrowserRouter basename={import.meta.env.BASE_URL.replace(/\/$/, "")}>
       <App />
     </BrowserRouter>
   </StrictMode>,


### PR DESCRIPTION
## Smoke tested

Aaron's browser smoke against the #20 stack hit `404 /api/discovery` from the hub origin's root — the SPA never bootstrapped. Inline fixes already in source (api.ts + auth.ts both derive from `BASE_URL`); team-lead rebuilt `dist/` with `VITE_BASE_PATH=/claw/ pnpm build`. Verified:

\`\`\`
$ ls web/ui/dist/assets/index-*.js
index-D0kkhRW4.js                                                       # ← fresh bundle

$ grep -o '\"/claw/\"\.replace[^,;]*' web/ui/dist/assets/index-D0kkhRW4.js
\"/claw/\".replace(/\\/$/                                                  # ← BrowserRouter basename (#20)
\"/claw/\".replace(/\\/$/                                                  # ← API_BASE              (this PR)
\"/claw/\".replace(/\\/$/                                                  # ← discovery URL         (this PR)
                                                                         #   all three mount-aware fixes baked in

$ curl -sS https://parachute.taildf9ce2.ts.net/claw/ | grep -oE 'index-[A-Za-z0-9]+\.js'
index-D0kkhRW4.js                                                       # ← tailnet serves the new bundle

$ curl -sS -i https://parachute.taildf9ce2.ts.net/claw/api/discovery | head -3
HTTP/2 200
content-type: application/json
{\"hubOrigin\":\"https://parachute.taildf9ce2.ts.net\"}                   # ← what the SPA fetches at boot

$ pnpm typecheck   # web/ui + root
both clean
\`\`\`

The minified bundle has all three `/claw/`-derived URL constructions: BrowserRouter basename (PR #20), API_BASE (this PR), and the discovery fetch URL (this PR). Tailnet hits paraclaw on every API path now instead of fanning bare \`/api/...\` to the hub.

Browser-interactive smoke (Aaron) — what to expect after a hard-refresh of \`https://parachute.taildf9ce2.ts.net/claw/\`:
- DevTools Network: \`GET /claw/api/discovery\` → 200 application/json
- OAuth flow kicks in (redirect to hub)
- After OAuth back: \`/claw/api/groups\` → 200 (or empty list)

## Summary

Two places hardcoded \`/api\` in the UI:
- \`web/ui/src/lib/api.ts\` — \`const API_BASE = \"/api\"\` made every fetch in the SPA hit the bare \`/api/...\` path on the origin.
- \`web/ui/src/lib/auth.ts\` — the discovery bootstrap fetched \`/api/discovery\` the same way.

On the tailnet, the parachute hub owns the origin's \`/\`, so an absolute \`/api/...\` from the browser goes to the **hub**, not paraclaw — and the hub 404s on it. The OAuth dance never starts because discovery never resolves. Local dev worked because Vite's dev server proxies \`/api/*\` → \`localhost:1944\` (paraclaw); the same path resolves to the same server in dev whether mount-prefixed or not. **Tailnet-only failure mode** — exactly the kind of thing that survives a unit-test gate and dies in browser smoke.

**Fix:** derive every UI-constructed URL from \`import.meta.env.BASE_URL\` — trailing slash trimmed when joining. Same bundle now works at \`/\`, \`/claw/\`, or any future mount.

\`\`\`ts
// api.ts
const API_BASE = \`\${import.meta.env.BASE_URL.replace(/\\/$/, \"\")}/api\`;

// auth.ts (getDiscovery)
const url = \`\${import.meta.env.BASE_URL.replace(/\\/$/, \"\")}/api/discovery\`;
\`\`\`

## CLAUDE.md update

Added a \"Web UI (mount-aware)\" section documenting the rule + pattern. Future UI work in paraclaw — and the same shape in any future Parachute service that ships a mounted SPA — should not re-import this bug. Pulled the same lesson into the cross-repo memory store as ecosystem-level feedback.

## Stacking

Stacked on \`fix/router-basename-trailing-slash\` (#20). Full chain: #16 → #17 → #19 → #20 → this. Each rebases trivially on the prior. Once #20 lands, retarget this to \`main\`.

RC bump web/ui only: 0.0.11-rc.1 → 0.0.12-rc.1 (web/server unchanged).

## Adjacent observation (out of scope)

Server should probably redirect \`/claw\` → \`/claw/\` for typed-URL ergonomics. Not blocking. Will file as a paraclaw issue if it stays a papercut after this stack lands.

## Test plan

- [x] \`pnpm typecheck\` — clean (web/ui + root)
- [x] Bundle inspection — three \`/claw/\".replace(/\\/$/\` usages baked in
- [x] \`/claw/api/discovery\` over tailnet → 200 application/json
- [x] Tailnet HTML references the new bundle hash
- [ ] Browser interactive — Aaron hard-refreshes, OAuth dance starts, groups list loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)