### PR TITLE
feat(ui): control-plane spawn button + canonical /claw/ vite base (closes #23, #25)

### DIFF
--- a/web/server/package.json
+++ b/web/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraclaw/web-server",
-  "version": "0.0.10-rc.1",
+  "version": "0.0.12-rc.1",
   "private": true,
   "description": "Paraclaw web UI server. Lists agent groups + manages vault attachments. Reuses NanoClaw's better-sqlite3 + Parachute attach helpers.",
   "license": "AGPL-3.0",

--- a/web/server/package.json
+++ b/web/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraclaw/web-server",
-  "version": "0.0.12-rc.1",
+  "version": "0.0.13-rc.1",
   "private": true,
   "description": "Paraclaw web UI server. Lists agent groups + manages vault attachments. Reuses NanoClaw's better-sqlite3 + Parachute attach helpers.",
   "license": "AGPL-3.0",

--- a/web/server/src/hub-discovery.test.ts
+++ b/web/server/src/hub-discovery.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests the hub-discovery client. The contract under test is the
+ * well-known shape (`vaults: [{name, url, version}]`) — same as
+ * `parachute-patterns/patterns/module-protocol.md` documents — and the
+ * 30s in-process cache so we don't hammer the hub.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { clearHubDiscoveryCache, fetchHubVaults } from './hub-discovery.js';
+
+let prevHubOrigin: string | undefined;
+
+beforeEach(() => {
+  prevHubOrigin = process.env.PARACHUTE_HUB_ORIGIN;
+  delete process.env.PARACLAW_HUB_ORIGIN;
+  process.env.PARACHUTE_HUB_ORIGIN = 'https://parachute.example';
+  clearHubDiscoveryCache();
+});
+
+afterEach(() => {
+  if (prevHubOrigin === undefined) delete process.env.PARACHUTE_HUB_ORIGIN;
+  else process.env.PARACHUTE_HUB_ORIGIN = prevHubOrigin;
+  clearHubDiscoveryCache();
+});
+
+function makeFetchStub(body: unknown, init: { ok?: boolean; status?: number } = {}) {
+  const ok = init.ok ?? true;
+  const status = init.status ?? (ok ? 200 : 500);
+  return vi.fn().mockResolvedValue({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'Error',
+    json: async () => body,
+  } as Response);
+}
+
+describe('fetchHubVaults', () => {
+  it('GETs /.well-known/parachute.json on the resolved hub origin', async () => {
+    const stub = makeFetchStub({ vaults: [] });
+    await fetchHubVaults(stub);
+    expect(stub).toHaveBeenCalledTimes(1);
+    expect(stub).toHaveBeenCalledWith(
+      'https://parachute.example/.well-known/parachute.json',
+      expect.objectContaining({ headers: { Accept: 'application/json' } }),
+    );
+  });
+
+  it('returns the vaults array as-is from the well-known doc', async () => {
+    const vaults = [
+      { name: 'default', url: 'https://parachute.example/vault/default', version: '0.3.0' },
+      { name: 'work', url: 'https://parachute.example/vault/work', version: '0.3.0' },
+    ];
+    const stub = makeFetchStub({ vaults });
+    expect(await fetchHubVaults(stub)).toEqual(vaults);
+  });
+
+  it('returns [] when the well-known has no vaults block', async () => {
+    const stub = makeFetchStub({ services: [] });
+    expect(await fetchHubVaults(stub)).toEqual([]);
+  });
+
+  it('caches results within the TTL — second call does not hit fetch', async () => {
+    const stub = makeFetchStub({ vaults: [{ name: 'default', url: 'https://h/vault/default', version: '0.3.0' }] });
+    let t = 1_000_000;
+    const now = () => t;
+    await fetchHubVaults(stub, now);
+    t += 5_000;
+    await fetchHubVaults(stub, now);
+    expect(stub).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches after the 30s TTL elapses', async () => {
+    const stub = makeFetchStub({ vaults: [] });
+    let t = 1_000_000;
+    const now = () => t;
+    await fetchHubVaults(stub, now);
+    t += 31_000;
+    await fetchHubVaults(stub, now);
+    expect(stub).toHaveBeenCalledTimes(2);
+  });
+
+  it('refetches when the hub origin changes (e.g. PARACHUTE_HUB_ORIGIN flipped)', async () => {
+    const stub = makeFetchStub({ vaults: [] });
+    let t = 1_000_000;
+    const now = () => t;
+    await fetchHubVaults(stub, now);
+    process.env.PARACHUTE_HUB_ORIGIN = 'https://other.example';
+    await fetchHubVaults(stub, now);
+    expect(stub).toHaveBeenCalledTimes(2);
+    expect(stub).toHaveBeenLastCalledWith(
+      'https://other.example/.well-known/parachute.json',
+      expect.anything(),
+    );
+  });
+
+  it('throws on non-2xx so the endpoint can surface the error to the UI', async () => {
+    const stub = makeFetchStub({}, { ok: false, status: 503 });
+    await expect(fetchHubVaults(stub)).rejects.toThrow(/503/);
+  });
+});

--- a/web/server/src/hub-discovery.ts
+++ b/web/server/src/hub-discovery.ts
@@ -1,0 +1,67 @@
+/**
+ * Read the hub's discovery doc to enumerate registered vaults.
+ *
+ * Source of truth: `<hubOrigin>/.well-known/parachute.json` (the documented
+ * discovery contract per `parachute-patterns/patterns/module-protocol.md`).
+ * The hub stamps `PARACHUTE_HUB_ORIGIN` on every lifecycle-spawned service
+ * (paraclaw#19); we resolve via `getHubOrigin()` so tailnet-hosted paraclaw
+ * sees its tailnet-routable hub origin.
+ *
+ * Why not `~/.parachute/services.json` directly: that file holds **port +
+ * loopback path**, which gives `http://127.0.0.1:<port>/vault/...`. The
+ * vault URL chosen here gets baked into each agent container's
+ * `container.json` as the MCP target. Loopback works only when the agent
+ * shares the host network namespace; for any non-host-network container
+ * (or peer-tailnet vault) the agent can't reach it. The well-known doc
+ * surfaces the public-routable URL (`https://<host>/vault/<label>`),
+ * which is the right thing to bake in.
+ *
+ * Cache: 30s in-process. Discovery is approximately static between
+ * installs — refreshing every few seconds would be wasteful, but caching
+ * forever would silently miss a freshly-installed vault. 30s is a balance
+ * users won't notice, and per-process restart clears it anyway.
+ */
+import { getHubOrigin } from './auth.js';
+
+export interface VaultListing {
+  name: string;
+  url: string;
+  version: string;
+}
+
+interface ParachuteDiscovery {
+  vaults?: VaultListing[];
+}
+
+const CACHE_TTL_MS = 30_000;
+
+interface CacheEntry {
+  origin: string;
+  fetchedAt: number;
+  vaults: VaultListing[];
+}
+
+let cache: CacheEntry | null = null;
+
+export function clearHubDiscoveryCache(): void {
+  cache = null;
+}
+
+export async function fetchHubVaults(
+  fetchImpl: typeof fetch = fetch,
+  now: () => number = Date.now,
+): Promise<VaultListing[]> {
+  const origin = getHubOrigin();
+  if (cache && cache.origin === origin && now() - cache.fetchedAt < CACHE_TTL_MS) {
+    return cache.vaults;
+  }
+  const url = `${origin}/.well-known/parachute.json`;
+  const res = await fetchImpl(url, { headers: { Accept: 'application/json' } });
+  if (!res.ok) {
+    throw new Error(`hub discovery ${res.status} ${res.statusText} from ${url}`);
+  }
+  const doc = (await res.json()) as ParachuteDiscovery;
+  const vaults = Array.isArray(doc.vaults) ? doc.vaults : [];
+  cache = { origin, fetchedAt: now(), vaults };
+  return vaults;
+}

--- a/web/server/src/server.ts
+++ b/web/server/src/server.ts
@@ -57,6 +57,7 @@ import {
   type AuthResult,
   type ClawScope,
 } from './auth.js';
+import { fetchHubVaults } from './hub-discovery.js';
 import { upsertService } from './services-manifest.js';
 import { makeServeStatic, normalizeMount } from './static-serve.js';
 
@@ -75,7 +76,7 @@ const HOST = process.env.PARACLAW_WEB_BIND ?? '127.0.0.1';
 // parachute-hub#83 ships) will set this from `module.json` `paths[0]`
 // automatically. Empty string = serve at the origin root (default).
 const MOUNT = normalizeMount(process.env.PARACLAW_WEB_MOUNT ?? '');
-const SERVICE_VERSION = '0.0.10-rc.1';
+const SERVICE_VERSION = '0.0.12-rc.1';
 
 // NanoClaw's mutating helpers (createAgentGroup, etc.) talk to a
 // process-singleton DB connection (`getDb`). Initialize it once at boot so
@@ -111,9 +112,7 @@ function listAgentGroups(): AgentGroupView[] {
   const db = getDb();
   try {
     const rows = db
-      .prepare(
-        'SELECT id, name, folder, agent_provider, created_at FROM agent_groups ORDER BY created_at DESC',
-      )
+      .prepare('SELECT id, name, folder, agent_provider, created_at FROM agent_groups ORDER BY created_at DESC')
       .all() as AgentGroupRow[];
     return rows.map((r) => ({
       ...r,
@@ -129,9 +128,7 @@ function getAgentGroup(folder: string): AgentGroupView | null {
   const db = getDb();
   try {
     const row = db
-      .prepare(
-        'SELECT id, name, folder, agent_provider, created_at FROM agent_groups WHERE folder = ?',
-      )
+      .prepare('SELECT id, name, folder, agent_provider, created_at FROM agent_groups WHERE folder = ?')
       .get(folder) as AgentGroupRow | undefined;
     if (!row) return null;
     return {
@@ -149,10 +146,7 @@ function getAgentGroup(folder: string): AgentGroupView | null {
  * `pvt_…` line. Used by the attach flow so the user never types/pastes a
  * raw token through the UI.
  */
-function mintVaultToken(opts: {
-  scope: VaultScope;
-  label: string;
-}): Promise<{ token: string; label: string }> {
+function mintVaultToken(opts: { scope: VaultScope; label: string }): Promise<{ token: string; label: string }> {
   return new Promise((resolve, reject) => {
     const args = ['vault', 'tokens', 'create', '--scope', opts.scope, '--label', opts.label];
     const proc = spawn('parachute', args, { stdio: ['ignore', 'pipe', 'pipe'] });
@@ -167,11 +161,7 @@ function mintVaultToken(opts: {
     proc.on('error', (err) => reject(err));
     proc.on('close', (code) => {
       if (code !== 0) {
-        reject(
-          new Error(
-            `parachute vault tokens create exited ${code}: ${stderr.trim() || stdout.trim()}`,
-          ),
-        );
+        reject(new Error(`parachute vault tokens create exited ${code}: ${stderr.trim() || stdout.trim()}`));
         return;
       }
       // Output shape (vault 0.3.x):
@@ -191,11 +181,7 @@ function mintVaultToken(opts: {
 
 // --- HTTP plumbing -----------------------------------------------------------
 
-const json = (
-  res: http.ServerResponse,
-  status: number,
-  body: unknown,
-): void => {
+const json = (res: http.ServerResponse, status: number, body: unknown): void => {
   res.writeHead(status, { 'content-type': 'application/json' });
   res.end(JSON.stringify(body));
 };
@@ -221,19 +207,12 @@ function send401or403(res: http.ServerResponse, fail: Extract<AuthResult, { ok: 
   if (fail.status === 401) {
     res.setHeader('WWW-Authenticate', 'Bearer');
   } else if (fail.errorType === 'insufficient_scope' && fail.requiredScope) {
-    res.setHeader(
-      'WWW-Authenticate',
-      `Bearer error="insufficient_scope", scope="${fail.requiredScope}"`,
-    );
+    res.setHeader('WWW-Authenticate', `Bearer error="insufficient_scope", scope="${fail.requiredScope}"`);
   }
   json(res, fail.status, body);
 }
 
-async function gate(
-  req: http.IncomingMessage,
-  res: http.ServerResponse,
-  required: ClawScope,
-): Promise<boolean> {
+async function gate(req: http.IncomingMessage, res: http.ServerResponse, required: ClawScope): Promise<boolean> {
   const result = await authenticate(req.headers.authorization, required);
   if (result.ok) return true;
   send401or403(res, result);
@@ -277,6 +256,23 @@ async function handleApi(
     return;
   }
 
+  // GET /api/vaults — enumerate registered vaults so the attach-vault
+  // picker can populate a dropdown. Sourced from the hub's well-known
+  // discovery doc (`<hubOrigin>/.well-known/parachute.json`), which
+  // returns the public-routable URL — critical because that URL gets
+  // baked into the agent container's MCP config and loopback would break
+  // any non-host-network agent.
+  if (pathname === '/api/vaults' && method === 'GET') {
+    if (!(await gate(req, res, SCOPE_CLAW_READ))) return;
+    try {
+      const vaults = await fetchHubVaults();
+      json(res, 200, { vaults });
+    } catch (err) {
+      error(res, 502, err instanceof Error ? err.message : String(err));
+    }
+    return;
+  }
+
   if (pathname === '/api/groups' && method === 'POST') {
     if (!(await gate(req, res, SCOPE_CLAW_WRITE))) return;
     try {
@@ -309,9 +305,7 @@ async function handleApi(
         return;
       }
 
-      let vaultArg:
-        | Parameters<typeof createParachuteAgentGroup>[0]['vault']
-        | undefined;
+      let vaultArg: Parameters<typeof createParachuteAgentGroup>[0]['vault'] | undefined;
       let mintedVaultToken = false;
       if (body.vault) {
         const scope = (body.vault.scope ?? 'vault:read') as VaultScope;
@@ -384,10 +378,7 @@ async function handleApi(
 
     // Pick the scope for the matching sub-route up front so we can gate
     // before any DB read. GET → read; POST → write.
-    const requiredScope: ClawScope =
-      sub === '' && method === 'GET'
-        ? SCOPE_CLAW_READ
-        : SCOPE_CLAW_WRITE;
+    const requiredScope: ClawScope = sub === '' && method === 'GET' ? SCOPE_CLAW_READ : SCOPE_CLAW_WRITE;
     if (!(await gate(req, res, requiredScope))) return;
 
     const group = getAgentGroup(folder);
@@ -527,8 +518,6 @@ server.listen(PORT, HOST, () => {
       tagline: 'Manage your Parachute agent groups + vault attachments.',
     });
   } catch (err) {
-    console.warn(
-      `paraclaw: skipped services manifest update: ${err instanceof Error ? err.message : err}`,
-    );
+    console.warn(`paraclaw: skipped services manifest update: ${err instanceof Error ? err.message : err}`);
   }
 });

--- a/web/server/src/server.ts
+++ b/web/server/src/server.ts
@@ -49,6 +49,9 @@ import {
   validateFolderSlug,
 } from '../../../src/parachute/create-agent.js';
 import { getGroupStatus, type GroupStatus } from '../../../src/parachute/group-status.js';
+import { resolveSession } from '../../../src/session-manager.js';
+import { wakeContainer } from '../../../src/container-runner.js';
+import { log } from '../../../src/log.js';
 import {
   authenticate,
   getHubOrigin,
@@ -76,7 +79,7 @@ const HOST = process.env.PARACLAW_WEB_BIND ?? '127.0.0.1';
 // parachute-hub#83 ships) will set this from `module.json` `paths[0]`
 // automatically. Empty string = serve at the origin root (default).
 const MOUNT = normalizeMount(process.env.PARACLAW_WEB_MOUNT ?? '');
-const SERVICE_VERSION = '0.0.12-rc.1';
+const SERVICE_VERSION = '0.0.13-rc.1';
 
 // NanoClaw's mutating helpers (createAgentGroup, etc.) talk to a
 // process-singleton DB connection (`getDb`). Initialize it once at boot so
@@ -428,6 +431,34 @@ async function handleApi(
         // Re-read so the response reflects the persisted state.
         const updated = getAgentGroup(folder);
         json(res, 200, { group: updated, mintedToken: !body.token });
+      } catch (err) {
+        error(res, 500, err instanceof Error ? err.message : String(err));
+      }
+      return;
+    }
+
+    // POST /api/groups/:folder/sessions — spawn (or wake) the agent-shared
+    // session for this group. Returns 202 immediately; container boot is
+    // fire-and-forget. The UI polls /api/groups/:folder for live status to
+    // see the session appear and the container come up. We choose
+    // 'agent-shared' mode because paraclaw-managed groups today are not
+    // wired to a messaging group at all (no Discord/Slack channel) — the
+    // claw runs in the background under whatever instructions live in
+    // its CLAUDE.md. agent-shared collapses to one session per group,
+    // which is the right shape for that no-channel case.
+    if (sub === '/sessions' && method === 'POST') {
+      try {
+        const { session, created } = resolveSession(group.id, null, null, 'agent-shared');
+        // Fire-and-forget: wakeContainer can take several seconds (image
+        // pull, mount setup, OneCLI agent ensure). Holding the request
+        // open that long would force the UI into a fake spinner; instead
+        // we 202 and let the existing /api/groups/:folder poll surface
+        // the live containerRunning state. Errors get logged on the host;
+        // the UI sees them as "container never came up" via the same poll.
+        void wakeContainer(session).catch((err) => {
+          log.error('paraclaw: wakeContainer failed', { sessionId: session.id, err });
+        });
+        json(res, 202, { sessionId: session.id, created });
       } catch (err) {
         error(res, 500, err instanceof Error ? err.message : String(err));
       }

--- a/web/server/src/services-manifest.test.ts
+++ b/web/server/src/services-manifest.test.ts
@@ -56,28 +56,16 @@ describe('upsertService', () => {
   });
 
   it('replaces an existing entry with the same name in-place', () => {
-    upsertService(
-      { name: 'claw', port: 1944, paths: ['/claw'], health: '/api/health', version: 'a' },
-      path,
-    );
-    upsertService(
-      { name: 'claw', port: 1944, paths: ['/claw'], health: '/api/health', version: 'b' },
-      path,
-    );
+    upsertService({ name: 'claw', port: 1944, paths: ['/claw'], health: '/api/health', version: 'a' }, path);
+    upsertService({ name: 'claw', port: 1944, paths: ['/claw'], health: '/api/health', version: 'b' }, path);
     const raw = JSON.parse(readFileSync(path, 'utf8')) as { services: { version: string }[] };
     expect(raw.services).toHaveLength(1);
     expect(raw.services[0].version).toBe('b');
   });
 
   it('appends a different-name entry without disturbing existing rows', () => {
-    upsertService(
-      { name: 'vault', port: 1940, paths: ['/vault'], health: '/health', version: '0.3.0' },
-      path,
-    );
-    upsertService(
-      { name: 'claw', port: 1944, paths: ['/claw'], health: '/api/health', version: '0.0.6-rc.1' },
-      path,
-    );
+    upsertService({ name: 'vault', port: 1940, paths: ['/vault'], health: '/health', version: '0.3.0' }, path);
+    upsertService({ name: 'claw', port: 1944, paths: ['/claw'], health: '/api/health', version: '0.0.6-rc.1' }, path);
     const raw = JSON.parse(readFileSync(path, 'utf8')) as {
       services: { name: string }[];
     };
@@ -126,10 +114,8 @@ describe('upsertService', () => {
   it('throws on a malformed existing manifest (so we never silently overwrite)', () => {
     writeFileSync(path, '{"services": "not an array"}');
     expect(() =>
-      upsertService(
-        { name: 'claw', port: 1944, paths: ['/claw'], health: '/api/health', version: 'x' },
-        path,
-      ),
+      upsertService({ name: 'claw', port: 1944, paths: ['/claw'], health: '/api/health', version: 'x' }, path),
     ).toThrow(/malformed/);
   });
 });
+

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@paraclaw/web-ui",
-  "version": "0.0.14-rc.1",
+  "version": "0.0.15-rc.1",
   "private": true,
   "description": "Paraclaw web UI — Vite + React + TypeScript. Manages vault attachments per agent group.",
   "license": "AGPL-3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && node scripts/verify-base.mjs",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit"
   },

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraclaw/web-ui",
-  "version": "0.0.12-rc.1",
+  "version": "0.0.14-rc.1",
   "private": true,
   "description": "Paraclaw web UI — Vite + React + TypeScript. Manages vault attachments per agent group.",
   "license": "AGPL-3.0",

--- a/web/ui/scripts/verify-base.mjs
+++ b/web/ui/scripts/verify-base.mjs
@@ -1,0 +1,31 @@
+// Regression check for parachute-patterns/patterns/mount-path-convention.md:
+// the canonical-mount default build must produce asset URLs prefixed with
+// `/claw/`. If `vite.config.ts`'s `base` ever drifts back to `/`, the bundle
+// HTML loses the prefix and 404s under the hub mount — exactly the silent
+// failure that motivated paraclaw#25.
+//
+// Skipped when VITE_BASE_PATH is set explicitly (legitimate override for
+// stand-alone or alternate-mount builds).
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const override = process.env.VITE_BASE_PATH;
+if (override && override !== "/claw/") {
+  console.log(`verify-base: VITE_BASE_PATH=${override} (override) — skipping default-mount check.`);
+  process.exit(0);
+}
+
+const html = readFileSync(resolve("dist/index.html"), "utf8");
+const wantPrefix = '/claw/assets/';
+const hasMounted = html.includes(`src="${wantPrefix}`) || html.includes(`href="${wantPrefix}`);
+if (!hasMounted) {
+  console.error(
+    "✖ verify-base: dist/index.html is missing /claw/-prefixed asset URLs.\n" +
+      "  This means vite's `base` resolved to something other than `/claw/`.\n" +
+      "  Check web/ui/vite.config.ts (default should be `/claw/`) and any\n" +
+      "  VITE_BASE_PATH env var leaking into the build environment.",
+  );
+  process.exit(1);
+}
+console.log("verify-base: ✓ dist/index.html references /claw/-prefixed assets.");

--- a/web/ui/src/components/VaultPicker.tsx
+++ b/web/ui/src/components/VaultPicker.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useRef, useState } from 'react';
+import { listVaults, type VaultListing } from '../lib/api.ts';
+
+interface VaultPickerProps {
+  value: string;
+  onChange: (next: string) => void;
+  disabled?: boolean;
+  inputId?: string;
+  /** Fires with the picked vault's display name (or null when "Other" is selected / no match). */
+  onPickedName?: (name: string | null) => void;
+}
+
+const OTHER_SENTINEL = '__other__';
+
+export function VaultPicker({ value, onChange, disabled, inputId, onPickedName }: VaultPickerProps) {
+  const [vaults, setVaults] = useState<VaultListing[] | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [useCustomUrl, setUseCustomUrl] = useState(false);
+  const initializedRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    listVaults()
+      .then((vs) => {
+        if (cancelled) return;
+        setVaults(vs);
+        if (initializedRef.current) return;
+        initializedRef.current = true;
+        if (vs.length === 0) {
+          setUseCustomUrl(true);
+          onPickedName?.(null);
+          return;
+        }
+        const match = vs.find((v) => v.url === value);
+        if (!match) onChange(vs[0].url);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setLoadError(e instanceof Error ? e.message : String(e));
+        setUseCustomUrl(true);
+        initializedRef.current = true;
+        onPickedName?.(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Notify parent when the picked-name changes (selection or value flip).
+  useEffect(() => {
+    if (!onPickedName) return;
+    if (useCustomUrl) {
+      onPickedName(null);
+      return;
+    }
+    if (!vaults) return;
+    const match = vaults.find((v) => v.url === value);
+    onPickedName(match ? match.name : null);
+  }, [vaults, value, useCustomUrl, onPickedName]);
+
+  const trimmed = value.replace(/\/+$/, '');
+  const reachLine = (
+    <p className="dim">
+      The agent will reach this at <code>{trimmed || '…'}/mcp</code>.
+    </p>
+  );
+
+  if (vaults === null && !loadError) {
+    return <p className="dim">Loading vaults…</p>;
+  }
+
+  const customInput = (
+    <input
+      id={vaults && vaults.length > 0 ? undefined : inputId}
+      type="text"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      disabled={disabled}
+      placeholder="https://parachute.example/vault/default"
+      style={vaults && vaults.length > 0 ? { marginTop: '0.5rem' } : undefined}
+    />
+  );
+
+  if (!vaults || vaults.length === 0) {
+    return (
+      <>
+        {customInput}
+        {reachLine}
+        {loadError && <p className="dim">(could not list registered vaults: {loadError})</p>}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <select
+        id={inputId}
+        value={useCustomUrl ? OTHER_SENTINEL : value}
+        onChange={(e) => {
+          if (e.target.value === OTHER_SENTINEL) {
+            setUseCustomUrl(true);
+          } else {
+            setUseCustomUrl(false);
+            onChange(e.target.value);
+          }
+        }}
+        disabled={disabled}
+      >
+        {vaults.map((v) => (
+          <option key={v.url} value={v.url}>
+            {v.name} — {v.url}
+          </option>
+        ))}
+        <option value={OTHER_SENTINEL}>Other (paste URL)…</option>
+      </select>
+      {useCustomUrl && customInput}
+      {reachLine}
+    </>
+  );
+}
+
+export function vaultLabelForUrl(vaults: VaultListing[] | null, url: string): string | null {
+  if (!vaults) return null;
+  const match = vaults.find((v) => v.url === url.replace(/\/+$/, ''));
+  return match ? match.name : null;
+}

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -155,6 +155,18 @@ export async function attachVault(
   );
 }
 
+export interface SpawnSessionResult {
+  sessionId: string;
+  created: boolean;
+}
+
+export async function spawnSession(folder: string): Promise<SpawnSessionResult> {
+  return request<SpawnSessionResult>(`/groups/${encodeURIComponent(folder)}/sessions`, {
+    method: "POST",
+    json: {},
+  });
+}
+
 export async function detachVault(folder: string, mcpName?: string): Promise<AgentGroupView> {
   const r = await request<{ group: AgentGroupView }>(`/groups/${encodeURIComponent(folder)}/detach-vault`, {
     method: 'POST',

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -9,15 +9,15 @@
  * fails the wrapper hard-redirects to login. /api/discovery is the one
  * exception — it's the bootstrap and is fetched directly by auth.ts.
  */
-import { beginLogin, clearTokens, getAccessToken, refreshAccessToken } from "./auth.ts";
+import { beginLogin, clearTokens, getAccessToken, refreshAccessToken } from './auth.ts';
 
 // Mount-aware: when paraclaw is served at /claw/ (under hub on tailnet), API
 // calls must go to /claw/api/* — the bare /api/* path goes to the hub origin's
 // root, where it 404s. BASE_URL has the trailing slash already; the trim keeps
 // us from emitting //api when BASE_URL is /.
-const API_BASE = `${import.meta.env.BASE_URL.replace(/\/$/, "")}/api`;
+const API_BASE = `${import.meta.env.BASE_URL.replace(/\/$/, '')}/api`;
 
-export type VaultScope = "vault:read" | "vault:write" | "vault:admin";
+export type VaultScope = 'vault:read' | 'vault:write' | 'vault:admin';
 
 export interface VaultAttachment {
   vaultBaseUrl: string;
@@ -28,8 +28,8 @@ export interface VaultAttachment {
 
 export interface SessionStatus {
   sessionId: string;
-  status: "active" | "closed";
-  containerStatus: "running" | "idle" | "stopped";
+  status: 'active' | 'closed';
+  containerStatus: 'running' | 'idle' | 'stopped';
   alive: boolean;
   lastHeartbeatAt: string | null;
   lastMessageInAt: string | null;
@@ -60,17 +60,17 @@ export interface AgentGroupView {
 
 async function doFetch(
   path: string,
-  init: RequestInit & { json?: unknown } | undefined,
+  init: (RequestInit & { json?: unknown }) | undefined,
   bearer: string | null,
 ): Promise<Response> {
   const headers: Record<string, string> = {
-    Accept: "application/json",
+    Accept: 'application/json',
     ...((init?.headers as Record<string, string>) ?? {}),
   };
   if (bearer) headers.Authorization = `Bearer ${bearer}`;
   let body: BodyInit | undefined = init?.body as BodyInit | undefined;
   if (init?.json !== undefined) {
-    headers["Content-Type"] = "application/json";
+    headers['Content-Type'] = 'application/json';
     body = JSON.stringify(init.json);
   }
   return fetch(`${API_BASE}${path}`, { ...init, headers, body });
@@ -89,10 +89,7 @@ async function readError(res: Response): Promise<string> {
   return message;
 }
 
-export async function request<T>(
-  path: string,
-  init?: RequestInit & { json?: unknown },
-): Promise<T> {
+export async function request<T>(path: string, init?: RequestInit & { json?: unknown }): Promise<T> {
   let bearer = getAccessToken();
   if (!bearer) {
     // No token at all — kick off the OAuth dance. beginLogin() never returns.
@@ -119,14 +116,26 @@ export async function request<T>(
 }
 
 export async function listGroups(): Promise<AgentGroupView[]> {
-  const r = await request<{ groups: AgentGroupView[] }>("/groups");
+  const r = await request<{ groups: AgentGroupView[] }>('/groups');
   return r.groups;
 }
 
+export interface VaultListing {
+  /** Vault display name from the hub's well-known discovery doc, e.g. `default`. */
+  name: string;
+  /** Public-routable URL the agent will reach the vault at, e.g. `https://parachute.taildf9ce2.ts.net/vault/default`. */
+  url: string;
+  /** Vault version the hub reports for this entry. */
+  version: string;
+}
+
+export async function listVaults(): Promise<VaultListing[]> {
+  const r = await request<{ vaults: VaultListing[] }>('/vaults');
+  return r.vaults;
+}
+
 export async function getGroup(folder: string): Promise<AgentGroupView> {
-  const r = await request<{ group: AgentGroupView }>(
-    `/groups/${encodeURIComponent(folder)}`,
-  );
+  const r = await request<{ group: AgentGroupView }>(`/groups/${encodeURIComponent(folder)}`);
   return r.group;
 }
 
@@ -142,15 +151,15 @@ export async function attachVault(
 ): Promise<{ group: AgentGroupView; mintedToken: boolean }> {
   return request<{ group: AgentGroupView; mintedToken: boolean }>(
     `/groups/${encodeURIComponent(folder)}/attach-vault`,
-    { method: "POST", json: input },
+    { method: 'POST', json: input },
   );
 }
 
 export async function detachVault(folder: string, mcpName?: string): Promise<AgentGroupView> {
-  const r = await request<{ group: AgentGroupView }>(
-    `/groups/${encodeURIComponent(folder)}/detach-vault`,
-    { method: "POST", json: { mcpName } },
-  );
+  const r = await request<{ group: AgentGroupView }>(`/groups/${encodeURIComponent(folder)}/detach-vault`, {
+    method: 'POST',
+    json: { mcpName },
+  });
   return r.group;
 }
 
@@ -162,15 +171,11 @@ export interface FolderAvailability {
 }
 
 export async function checkFolderAvailability(slug: string): Promise<FolderAvailability> {
-  return request<FolderAvailability>(
-    `/folder-availability/${encodeURIComponent(slug)}`,
-  );
+  return request<FolderAvailability>(`/folder-availability/${encodeURIComponent(slug)}`);
 }
 
 export async function fetchFolderSuggestion(name: string): Promise<string> {
-  const r = await request<{ name: string; slug: string }>(
-    `/folder-suggestion?name=${encodeURIComponent(name)}`,
-  );
+  const r = await request<{ name: string; slug: string }>(`/folder-suggestion?name=${encodeURIComponent(name)}`);
   return r.slug;
 }
 
@@ -191,8 +196,5 @@ export async function createGroup(input: CreateGroupInput): Promise<{
   group: AgentGroupView;
   mintedVaultToken: boolean;
 }> {
-  return request<{ group: AgentGroupView; mintedVaultToken: boolean }>(
-    `/groups`,
-    { method: "POST", json: input },
-  );
+  return request<{ group: AgentGroupView; mintedVaultToken: boolean }>(`/groups`, { method: 'POST', json: input });
 }

--- a/web/ui/src/routes/GroupDetail.tsx
+++ b/web/ui/src/routes/GroupDetail.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useState } from "react";
-import { Link, useParams } from "react-router-dom";
-import { ScopeGrants, SCOPE_OPTIONS } from "../components/ScopeGrants.tsx";
-import { StatusDot, formatRelative } from "../components/StatusDot.tsx";
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { ScopeGrants, SCOPE_OPTIONS } from '../components/ScopeGrants.tsx';
+import { StatusDot, formatRelative } from '../components/StatusDot.tsx';
+import { VaultPicker } from '../components/VaultPicker.tsx';
 import {
   attachVault,
   detachVault,
@@ -9,7 +10,7 @@ import {
   type AgentGroupView,
   type GroupStatus,
   type VaultScope,
-} from "../lib/api.ts";
+} from '../lib/api.ts';
 
 const POLL_MS = 7_000;
 
@@ -19,13 +20,16 @@ export function GroupDetail() {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
-  // Attach form state.
-  const [scope, setScope] = useState<VaultScope>("vault:read");
-  const [vaultBaseUrl, setVaultBaseUrl] = useState("http://127.0.0.1:1940/vault/default");
-  const [pasteToken, setPasteToken] = useState("");
-  const [tokenLabel, setTokenLabel] = useState("");
+  // Attach form state. vaultBaseUrl starts empty — VaultPicker fills it in
+  // with the first registered vault's URL once /api/vaults resolves, or
+  // surfaces a free-text input when discovery is empty / errors.
+  const [scope, setScope] = useState<VaultScope>('vault:read');
+  const [vaultBaseUrl, setVaultBaseUrl] = useState('');
+  const [pickedVaultName, setPickedVaultName] = useState<string | null>(null);
+  const [pasteToken, setPasteToken] = useState('');
+  const [tokenLabel, setTokenLabel] = useState('');
   const [submitting, setSubmitting] = useState(false);
-  const [flash, setFlash] = useState<{ kind: "ok" | "error"; text: string } | null>(null);
+  const [flash, setFlash] = useState<{ kind: 'ok' | 'error'; text: string } | null>(null);
 
   const reload = useCallback(async () => {
     if (!folder) return;
@@ -67,21 +71,21 @@ export function GroupDetail() {
     try {
       const result = await attachVault(folder, {
         scope,
-        vaultBaseUrl: vaultBaseUrl.trim().replace(/\/+$/, ""),
+        vaultBaseUrl: vaultBaseUrl.trim().replace(/\/+$/, ''),
         tokenLabel: tokenLabel.trim() || undefined,
         token: pasteToken.trim() || undefined,
       });
       setGroup(result.group);
       setFlash({
-        kind: "ok",
+        kind: 'ok',
         text: result.mintedToken
           ? `Vault attached (server minted a fresh ${scope} token via parachute CLI).`
           : `Vault attached using your pasted token.`,
       });
-      setPasteToken("");
+      setPasteToken('');
     } catch (err) {
       setFlash({
-        kind: "error",
+        kind: 'error',
         text: err instanceof Error ? err.message : String(err),
       });
     } finally {
@@ -100,12 +104,12 @@ export function GroupDetail() {
       const updated = await detachVault(folder);
       setGroup(updated);
       setFlash({
-        kind: "ok",
-        text: "Vault detached. To revoke the token: parachute vault tokens revoke <label>",
+        kind: 'ok',
+        text: 'Vault detached. To revoke the token: parachute vault tokens revoke <label>',
       });
     } catch (err) {
       setFlash({
-        kind: "error",
+        kind: 'error',
         text: err instanceof Error ? err.message : String(err),
       });
     } finally {
@@ -116,12 +120,14 @@ export function GroupDetail() {
   if (loading && !group) {
     return (
       <div>
-        <Link to="/" className="muted">← All groups</Link>
-        <div className="skeleton skeleton-heading" style={{ marginTop: "1rem" }} />
+        <Link to="/" className="muted">
+          ← All groups
+        </Link>
+        <div className="skeleton skeleton-heading" style={{ marginTop: '1rem' }} />
         <div className="section">
-          <div className="skeleton skeleton-line" style={{ width: "30%" }} />
+          <div className="skeleton skeleton-line" style={{ width: '30%' }} />
           <div className="skeleton skeleton-line" />
-          <div className="skeleton skeleton-line" style={{ width: "70%" }} />
+          <div className="skeleton skeleton-line" style={{ width: '70%' }} />
         </div>
       </div>
     );
@@ -130,11 +136,15 @@ export function GroupDetail() {
   if (error) {
     return (
       <div>
-        <Link to="/" className="muted">← All groups</Link>
-        <div className="error-banner" style={{ marginTop: "1rem" }}>{error}</div>
-        <div className="actions" style={{ marginTop: "1rem" }}>
+        <Link to="/" className="muted">
+          ← All groups
+        </Link>
+        <div className="error-banner" style={{ marginTop: '1rem' }}>
+          {error}
+        </div>
+        <div className="actions" style={{ marginTop: '1rem' }}>
           <button onClick={reload} disabled={loading}>
-            {loading ? "Retrying…" : "Retry"}
+            {loading ? 'Retrying…' : 'Retry'}
           </button>
         </div>
       </div>
@@ -144,7 +154,9 @@ export function GroupDetail() {
   if (!group) {
     return (
       <div>
-        <Link to="/" className="muted">← All groups</Link>
+        <Link to="/" className="muted">
+          ← All groups
+        </Link>
         <div className="empty">Group not found.</div>
       </div>
     );
@@ -152,8 +164,10 @@ export function GroupDetail() {
 
   return (
     <div>
-      <Link to="/" className="muted">← All groups</Link>
-      <h2 style={{ display: "flex", alignItems: "center", gap: "0.6rem" }}>
+      <Link to="/" className="muted">
+        ← All groups
+      </Link>
+      <h2 style={{ display: 'flex', alignItems: 'center', gap: '0.6rem' }}>
         <StatusDot status={group.status} />
         {group.name}
         {group.vault ? (
@@ -163,20 +177,25 @@ export function GroupDetail() {
         )}
       </h2>
 
-      {flash && (
-        <div className={flash.kind === "ok" ? "status-banner" : "error-banner"}>
-          {flash.text}
-        </div>
-      )}
+      {flash && <div className={flash.kind === 'ok' ? 'status-banner' : 'error-banner'}>{flash.text}</div>}
 
       <div className="section">
         <h3>Agent group</h3>
         <div className="kv">
-          <div>name</div><div>{group.name}</div>
-          <div>folder</div><div><code>{group.folder}</code></div>
-          <div>id</div><div><code>{group.id}</code></div>
-          <div>provider</div><div>{group.agent_provider ?? <em className="dim">default</em>}</div>
-          <div>created</div><div>{new Date(group.created_at).toLocaleString()}</div>
+          <div>name</div>
+          <div>{group.name}</div>
+          <div>folder</div>
+          <div>
+            <code>{group.folder}</code>
+          </div>
+          <div>id</div>
+          <div>
+            <code>{group.id}</code>
+          </div>
+          <div>provider</div>
+          <div>{group.agent_provider ?? <em className="dim">default</em>}</div>
+          <div>created</div>
+          <div>{new Date(group.created_at).toLocaleString()}</div>
         </div>
       </div>
 
@@ -186,38 +205,44 @@ export function GroupDetail() {
         <div className="section">
           <h3>Vault attachment</h3>
           <div className="kv">
-            <div>vault url</div><div><code>{group.vault.vaultBaseUrl}</code></div>
-            <div>scope</div><div><span className="tag">{group.vault.scope}</span></div>
-            <div>token label</div><div><code>{group.vault.tokenLabel}</code></div>
-            <div>attached</div><div>{new Date(group.vault.attachedAt).toLocaleString()}</div>
+            <div>vault url</div>
+            <div>
+              <code>{group.vault.vaultBaseUrl}</code>
+            </div>
+            <div>scope</div>
+            <div>
+              <span className="tag">{group.vault.scope}</span>
+            </div>
+            <div>token label</div>
+            <div>
+              <code>{group.vault.tokenLabel}</code>
+            </div>
+            <div>attached</div>
+            <div>{new Date(group.vault.attachedAt).toLocaleString()}</div>
           </div>
           <hr className="sep" />
-          <div className="dim" style={{ marginBottom: "0.75rem" }}>
-            The agent's container.json has a <code>parachute-vault</code> MCP entry pointing at this URL with a Bearer token. Detach removes the entry; the token stays valid until you revoke it via{" "}
+          <div className="dim" style={{ marginBottom: '0.75rem' }}>
+            The agent's container.json has a <code>parachute-vault</code> MCP entry pointing at this URL with a Bearer
+            token. Detach removes the entry; the token stays valid until you revoke it via{' '}
             <code>parachute vault tokens revoke {group.vault.tokenLabel}</code>.
           </div>
           <button className="danger" onClick={onDetach} disabled={submitting}>
-            {submitting ? "Working…" : "Detach vault"}
+            {submitting ? 'Working…' : 'Detach vault'}
           </button>
         </div>
       ) : (
         <div className="section">
-          <h3>Attach vault</h3>
+          <h3>Attach {pickedVaultName ? <code>{pickedVaultName}</code> : null} vault</h3>
           <form onSubmit={onAttach}>
             <div className="row">
-              <label htmlFor="vaultBaseUrl">Vault URL</label>
-              <input
-                id="vaultBaseUrl"
-                type="text"
+              <label htmlFor="vaultBaseUrl">Vault</label>
+              <VaultPicker
+                inputId="vaultBaseUrl"
                 value={vaultBaseUrl}
-                onChange={(e) => setVaultBaseUrl(e.target.value)}
+                onChange={setVaultBaseUrl}
+                onPickedName={setPickedVaultName}
                 disabled={submitting}
               />
-              <p className="dim">
-                The agent will reach this at{" "}
-                <code>{vaultBaseUrl.replace(/\/+$/, "")}/mcp</code>. Default
-                is the local vault at <code>http://127.0.0.1:1940/vault/default</code>.
-              </p>
             </div>
 
             <div className="row">
@@ -266,16 +291,18 @@ export function GroupDetail() {
                 placeholder="pvt_…  (leave blank to mint a fresh one via the parachute CLI)"
               />
               <p className="dim">
-                When blank: the server runs{" "}
-                <code>parachute vault tokens create --scope {scope} --label {tokenLabel || `claw-${folder}`}</code>
-                {" "}for you. (Until vault OAuth is wired in Phase B; then
-                you'll never see <code>pvt_…</code> tokens at all.)
+                When blank: the server runs{' '}
+                <code>
+                  parachute vault tokens create --scope {scope} --label {tokenLabel || `claw-${folder}`}
+                </code>{' '}
+                for you. (Until vault OAuth is wired in Phase B; then you'll never see <code>pvt_…</code> tokens at
+                all.)
               </p>
             </div>
 
             <div className="actions">
               <button type="submit" disabled={submitting}>
-                {submitting ? "Attaching…" : "Attach vault"}
+                {submitting ? 'Attaching…' : 'Attach vault'}
               </button>
             </div>
           </form>
@@ -285,17 +312,13 @@ export function GroupDetail() {
       <div className="section">
         <h3>What the agent gets</h3>
         <p className="muted">
-          When attached, the agent's container has a{" "}
-          <code>parachute-vault</code> MCP server available with the nine
-          vault tools: <code>query-notes</code>, <code>create-note</code>,{" "}
-          <code>update-note</code>, <code>delete-note</code>,{" "}
-          <code>list-tags</code>, <code>update-tag</code>,{" "}
-          <code>delete-tag</code>, <code>find-path</code>,{" "}
-          <code>vault-info</code>. Constrained by the scope you chose.
+          When attached, the agent's container has a <code>parachute-vault</code> MCP server available with the nine
+          vault tools: <code>query-notes</code>, <code>create-note</code>, <code>update-note</code>,{' '}
+          <code>delete-note</code>, <code>list-tags</code>, <code>update-tag</code>, <code>delete-tag</code>,{' '}
+          <code>find-path</code>, <code>vault-info</code>. Constrained by the scope you chose.
         </p>
         <p className="muted">
-          Paraclaw doesn't impose a vault-note layout on the agent — the
-          claw decides how to use vault access. (See{" "}
+          Paraclaw doesn't impose a vault-note layout on the agent — the claw decides how to use vault access. (See{' '}
           <a
             href="https://github.com/ParachuteComputer/paraclaw/blob/main/docs/parachute-integration.md"
             target="_blank"
@@ -324,12 +347,14 @@ function StatusSection({ status }: { status: GroupStatus }) {
           )}
         </div>
         <div>active sessions</div>
-        <div>{status.activeSessionCount} of {status.sessionCount}</div>
+        <div>
+          {status.activeSessionCount} of {status.sessionCount}
+        </div>
         <div>last heartbeat</div>
         <div>
           {status.lastHeartbeatAt ? (
             <>
-              {formatRelative(status.lastHeartbeatAt)}{" "}
+              {formatRelative(status.lastHeartbeatAt)}{' '}
               <span className="dim">({new Date(status.lastHeartbeatAt).toLocaleString()})</span>
             </>
           ) : (
@@ -340,7 +365,7 @@ function StatusSection({ status }: { status: GroupStatus }) {
         <div>
           {status.lastMessageInAt ? (
             <>
-              {formatRelative(status.lastMessageInAt)}{" "}
+              {formatRelative(status.lastMessageInAt)}{' '}
               <span className="dim">({new Date(status.lastMessageInAt).toLocaleString()})</span>
             </>
           ) : (
@@ -351,7 +376,7 @@ function StatusSection({ status }: { status: GroupStatus }) {
         <div>
           {status.lastMessageOutAt ? (
             <>
-              {formatRelative(status.lastMessageOutAt)}{" "}
+              {formatRelative(status.lastMessageOutAt)}{' '}
               <span className="dim">({new Date(status.lastMessageOutAt).toLocaleString()})</span>
             </>
           ) : (
@@ -362,22 +387,23 @@ function StatusSection({ status }: { status: GroupStatus }) {
       {status.sessions.length > 0 && (
         <>
           <hr className="sep" />
-          <div className="dim" style={{ marginBottom: "0.5rem" }}>
+          <div className="dim" style={{ marginBottom: '0.5rem' }}>
             Sessions ({status.sessions.length}):
           </div>
           <ul className="session-list">
             {status.sessions.map((s) => (
               <li key={s.sessionId}>
-                <code>{s.sessionId}</code>{" "}
+                <code>{s.sessionId}</code>{' '}
                 {s.alive ? (
                   <span className="status-text alive">alive</span>
                 ) : (
                   <span className="status-text idle">{s.containerStatus}</span>
-                )}{" "}
+                )}{' '}
                 <span className="dim">— {s.status}</span>
                 {s.lastHeartbeatAt && (
                   <>
-                    {" "}<span className="dim">· hb {formatRelative(s.lastHeartbeatAt)}</span>
+                    {' '}
+                    <span className="dim">· hb {formatRelative(s.lastHeartbeatAt)}</span>
                   </>
                 )}
               </li>

--- a/web/ui/src/routes/GroupDetail.tsx
+++ b/web/ui/src/routes/GroupDetail.tsx
@@ -7,6 +7,7 @@ import {
   attachVault,
   detachVault,
   getGroup,
+  spawnSession,
   type AgentGroupView,
   type GroupStatus,
   type VaultScope,
@@ -29,6 +30,7 @@ export function GroupDetail() {
   const [pasteToken, setPasteToken] = useState('');
   const [tokenLabel, setTokenLabel] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const [spawning, setSpawning] = useState(false);
   const [flash, setFlash] = useState<{ kind: 'ok' | 'error'; text: string } | null>(null);
 
   const reload = useCallback(async () => {
@@ -90,6 +92,32 @@ export function GroupDetail() {
       });
     } finally {
       setSubmitting(false);
+    }
+  };
+
+  const onSpawn = async () => {
+    if (!folder) return;
+    setSpawning(true);
+    setFlash(null);
+    try {
+      const result = await spawnSession(folder);
+      // Reload immediately so the new session shows up in the live-status
+      // list before the next 7s poll tick. Container `running` flips on a
+      // later tick once the heartbeat lands.
+      await reload();
+      setFlash({
+        kind: 'ok',
+        text: result.created
+          ? `Session ${result.sessionId} created — container starting…`
+          : `Session ${result.sessionId} already exists — waking container…`,
+      });
+    } catch (err) {
+      setFlash({
+        kind: 'error',
+        text: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setSpawning(false);
     }
   };
 
@@ -199,7 +227,9 @@ export function GroupDetail() {
         </div>
       </div>
 
-      {group.status && <StatusSection status={group.status} />}
+      {group.status && (
+        <StatusSection status={group.status} onSpawn={onSpawn} spawning={spawning} />
+      )}
 
       {group.vault ? (
         <div className="section">
@@ -333,11 +363,24 @@ export function GroupDetail() {
   );
 }
 
-function StatusSection({ status }: { status: GroupStatus }) {
+function StatusSection({
+  status,
+  onSpawn,
+  spawning,
+}: {
+  status: GroupStatus;
+  onSpawn: () => void;
+  spawning: boolean;
+}) {
   return (
     <div className="section">
-      <h3>Live status</h3>
-      <div className="kv">
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '1rem' }}>
+        <h3 style={{ margin: 0 }}>Live status</h3>
+        <button onClick={onSpawn} disabled={spawning}>
+          {spawning ? 'Spawning…' : '+ New session'}
+        </button>
+      </div>
+      <div className="kv" style={{ marginTop: '1rem' }}>
         <div>container</div>
         <div>
           {status.containerRunning ? (
@@ -384,9 +427,13 @@ function StatusSection({ status }: { status: GroupStatus }) {
           )}
         </div>
       </div>
-      {status.sessions.length > 0 && (
+      <hr className="sep" />
+      {status.sessions.length === 0 ? (
+        <p className="dim" style={{ marginBottom: 0 }}>
+          No sessions yet — spawn one with the button above to start the agent's container.
+        </p>
+      ) : (
         <>
-          <hr className="sep" />
           <div className="dim" style={{ marginBottom: '0.5rem' }}>
             Sessions ({status.sessions.length}):
           </div>

--- a/web/ui/src/routes/NewGroupWizard.tsx
+++ b/web/ui/src/routes/NewGroupWizard.tsx
@@ -1,36 +1,39 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
-import { ScopeGrants, SCOPE_OPTIONS } from "../components/ScopeGrants.tsx";
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { ScopeGrants, SCOPE_OPTIONS } from '../components/ScopeGrants.tsx';
+import { VaultPicker } from '../components/VaultPicker.tsx';
 import {
   checkFolderAvailability,
   createGroup,
   fetchFolderSuggestion,
   type FolderAvailability,
   type VaultScope,
-} from "../lib/api.ts";
+} from '../lib/api.ts';
 
-type Step = "identity" | "vault" | "confirm";
-
-const DEFAULT_VAULT_URL = "http://127.0.0.1:1940/vault/default";
+type Step = 'identity' | 'vault' | 'confirm';
 
 export function NewGroupWizard() {
   const navigate = useNavigate();
-  const [step, setStep] = useState<Step>("identity");
+  const [step, setStep] = useState<Step>('identity');
 
   // Identity.
-  const [name, setName] = useState("");
-  const [folder, setFolder] = useState("");
+  const [name, setName] = useState('');
+  const [folder, setFolder] = useState('');
   const [folderTouched, setFolderTouched] = useState(false);
-  const [instructions, setInstructions] = useState("");
+  const [instructions, setInstructions] = useState('');
   const [folderCheck, setFolderCheck] = useState<FolderAvailability | null>(null);
   const [folderChecking, setFolderChecking] = useState(false);
 
   // Vault.
   const [attachVault, setAttachVault] = useState(false);
-  const [scope, setScope] = useState<VaultScope>("vault:read");
-  const [vaultBaseUrl, setVaultBaseUrl] = useState(DEFAULT_VAULT_URL);
-  const [pasteToken, setPasteToken] = useState("");
-  const [tokenLabel, setTokenLabel] = useState("");
+  const [scope, setScope] = useState<VaultScope>('vault:read');
+  // Empty initial value — VaultPicker fills it in with the first registered
+  // vault's URL once /api/vaults resolves, or surfaces a free-text input
+  // when discovery is empty / errors.
+  const [vaultBaseUrl, setVaultBaseUrl] = useState('');
+  const [pickedVaultName, setPickedVaultName] = useState<string | null>(null);
+  const [pasteToken, setPasteToken] = useState('');
+  const [tokenLabel, setTokenLabel] = useState('');
 
   // Submit.
   const [submitting, setSubmitting] = useState(false);
@@ -41,7 +44,7 @@ export function NewGroupWizard() {
     if (folderTouched) return;
     const trimmed = name.trim();
     if (!trimmed) {
-      setFolder("");
+      setFolder('');
       return;
     }
     let cancelled = false;
@@ -87,10 +90,7 @@ export function NewGroupWizard() {
   }, [folder]);
 
   const identityReady =
-    name.trim().length > 0 &&
-    folder.length > 0 &&
-    folderCheck?.valid === true &&
-    folderCheck?.available === true;
+    name.trim().length > 0 && folder.length > 0 && folderCheck?.valid === true && folderCheck?.available === true;
 
   const onFolderChange = useCallback((next: string) => {
     setFolderTouched(true);
@@ -108,7 +108,7 @@ export function NewGroupWizard() {
         vault: attachVault
           ? {
               scope,
-              vaultBaseUrl: vaultBaseUrl.trim().replace(/\/+$/, "") || DEFAULT_VAULT_URL,
+              vaultBaseUrl: vaultBaseUrl.trim().replace(/\/+$/, ''),
               tokenLabel: tokenLabel.trim() || undefined,
               token: pasteToken.trim() || undefined,
             }
@@ -124,17 +124,19 @@ export function NewGroupWizard() {
 
   return (
     <div>
-      <Link to="/" className="muted">← All groups</Link>
-      <h2 style={{ marginTop: "0.5rem" }}>New agent group</h2>
+      <Link to="/" className="muted">
+        ← All groups
+      </Link>
+      <h2 style={{ marginTop: '0.5rem' }}>New agent group</h2>
       <WizardSteps current={step} />
 
-      {step === "identity" && (
+      {step === 'identity' && (
         <div className="section">
           <h3>Identity</h3>
           <form
             onSubmit={(e) => {
               e.preventDefault();
-              if (identityReady) setStep("vault");
+              if (identityReady) setStep('vault');
             }}
           >
             <div className="row">
@@ -147,9 +149,7 @@ export function NewGroupWizard() {
                 placeholder="e.g. Forge"
                 autoFocus
               />
-              <p className="dim">
-                The display name. Folder slug is derived from this — you can override below.
-              </p>
+              <p className="dim">The display name. Folder slug is derived from this — you can override below.</p>
             </div>
 
             <div className="row">
@@ -172,33 +172,32 @@ export function NewGroupWizard() {
                 onChange={(e) => setInstructions(e.target.value)}
                 placeholder="Goes into CLAUDE.local.md. Leave blank for the default."
               />
-              <p className="dim">
-                What the agent should know about itself. Empty = the standard scaffold.
-              </p>
+              <p className="dim">What the agent should know about itself. Empty = the standard scaffold.</p>
             </div>
 
             <div className="actions">
-              <button type="submit" disabled={!identityReady}>Next: vault</button>
-              <Link to="/" className="muted" style={{ marginLeft: "0.5rem" }}>Cancel</Link>
+              <button type="submit" disabled={!identityReady}>
+                Next: vault
+              </button>
+              <Link to="/" className="muted" style={{ marginLeft: '0.5rem' }}>
+                Cancel
+              </Link>
             </div>
           </form>
         </div>
       )}
 
-      {step === "vault" && (
+      {step === 'vault' && (
         <div className="section">
           <h3>Vault attachment</h3>
           <p className="muted">
-            Attach the parachute vault now, or skip and attach later from the group's detail page.
+            Attach {pickedVaultName ? <code>{pickedVaultName}</code> : 'a'} parachute vault now, or skip and attach later
+            from the group's detail page.
           </p>
 
-          <div className="row" style={{ marginTop: "0.5rem" }}>
+          <div className="row" style={{ marginTop: '0.5rem' }}>
             <label className="wizard-toggle">
-              <input
-                type="checkbox"
-                checked={attachVault}
-                onChange={(e) => setAttachVault(e.target.checked)}
-              />
+              <input type="checkbox" checked={attachVault} onChange={(e) => setAttachVault(e.target.checked)} />
               <span>Attach vault now</span>
             </label>
           </div>
@@ -206,25 +205,18 @@ export function NewGroupWizard() {
           {attachVault && (
             <>
               <div className="row">
-                <label htmlFor="vaultBaseUrl">Vault URL</label>
-                <input
-                  id="vaultBaseUrl"
-                  type="text"
+                <label htmlFor="vaultBaseUrl">Vault</label>
+                <VaultPicker
+                  inputId="vaultBaseUrl"
                   value={vaultBaseUrl}
-                  onChange={(e) => setVaultBaseUrl(e.target.value)}
+                  onChange={setVaultBaseUrl}
+                  onPickedName={setPickedVaultName}
                 />
-                <p className="dim">
-                  Default is the local vault at <code>{DEFAULT_VAULT_URL}</code>.
-                </p>
               </div>
 
               <div className="row">
                 <label htmlFor="scope">Scope</label>
-                <select
-                  id="scope"
-                  value={scope}
-                  onChange={(e) => setScope(e.target.value as VaultScope)}
-                >
+                <select id="scope" value={scope} onChange={(e) => setScope(e.target.value as VaultScope)}>
                   {SCOPE_OPTIONS.map((s) => (
                     <option key={s.value} value={s.value}>
                       {s.label}
@@ -241,10 +233,10 @@ export function NewGroupWizard() {
                   type="text"
                   value={tokenLabel}
                   onChange={(e) => setTokenLabel(e.target.value)}
-                  placeholder={`claw-${folder || "<folder>"}`}
+                  placeholder={`claw-${folder || '<folder>'}`}
                 />
                 <p className="dim">
-                  Used for revocation. Default: <code>claw-{folder || "<folder>"}</code>.
+                  Used for revocation. Default: <code>claw-{folder || '<folder>'}</code>.
                 </p>
               </div>
 
@@ -264,27 +256,34 @@ export function NewGroupWizard() {
             </>
           )}
 
-          <div className="actions" style={{ marginTop: "1rem" }}>
-            <button className="secondary" onClick={() => setStep("identity")}>Back</button>
-            <button onClick={() => setStep("confirm")}>Next: confirm</button>
+          <div className="actions" style={{ marginTop: '1rem' }}>
+            <button className="secondary" onClick={() => setStep('identity')}>
+              Back
+            </button>
+            <button onClick={() => setStep('confirm')}>Next: confirm</button>
           </div>
         </div>
       )}
 
-      {step === "confirm" && (
+      {step === 'confirm' && (
         <div className="section">
           <h3>Confirm</h3>
           <div className="kv">
-            <div>name</div><div>{name}</div>
-            <div>folder</div><div><code>{folder}</code></div>
+            <div>name</div>
+            <div>{name}</div>
+            <div>folder</div>
+            <div>
+              <code>{folder}</code>
+            </div>
             <div>instructions</div>
             <div>{instructions.trim() ? <em>(custom)</em> : <span className="dim">default</span>}</div>
             <div>vault</div>
             <div>
               {attachVault ? (
                 <>
-                  <span className="tag">{scope}</span>{" "}
-                  <code>{vaultBaseUrl.trim().replace(/\/+$/, "") || DEFAULT_VAULT_URL}</code>
+                  <span className="tag">{scope}</span>{' '}
+                  {pickedVaultName ? <code>{pickedVaultName}</code> : null}{' '}
+                  <code>{vaultBaseUrl.trim().replace(/\/+$/, '')}</code>
                 </>
               ) : (
                 <span className="dim">skip — attach later</span>
@@ -293,27 +292,33 @@ export function NewGroupWizard() {
             {attachVault && (
               <>
                 <div>token label</div>
-                <div><code>{tokenLabel.trim() || `claw-${folder}`}</code></div>
+                <div>
+                  <code>{tokenLabel.trim() || `claw-${folder}`}</code>
+                </div>
                 <div>token</div>
                 <div>
-                  {pasteToken.trim()
-                    ? <span className="dim">using pasted token</span>
-                    : <span className="dim">server will mint a fresh token</span>}
+                  {pasteToken.trim() ? (
+                    <span className="dim">using pasted token</span>
+                  ) : (
+                    <span className="dim">server will mint a fresh token</span>
+                  )}
                 </div>
               </>
             )}
           </div>
 
           {submitError && (
-            <div className="error-banner" style={{ marginTop: "1rem" }}>{submitError}</div>
+            <div className="error-banner" style={{ marginTop: '1rem' }}>
+              {submitError}
+            </div>
           )}
 
-          <div className="actions" style={{ marginTop: "1rem" }}>
-            <button className="secondary" onClick={() => setStep("vault")} disabled={submitting}>
+          <div className="actions" style={{ marginTop: '1rem' }}>
+            <button className="secondary" onClick={() => setStep('vault')} disabled={submitting}>
               Back
             </button>
             <button onClick={onCreate} disabled={submitting}>
-              {submitting ? "Creating…" : "Create agent group"}
+              {submitting ? 'Creating…' : 'Create agent group'}
             </button>
           </div>
         </div>
@@ -339,13 +344,17 @@ function FolderHint({
     );
   }
   if (checking || !check) {
-    return <p className="dim">Checking <code>{folder}</code>…</p>;
+    return (
+      <p className="dim">
+        Checking <code>{folder}</code>…
+      </p>
+    );
   }
   if (!check.valid) {
-    return <p className="wizard-folder-error">{check.reason ?? "Invalid slug."}</p>;
+    return <p className="wizard-folder-error">{check.reason ?? 'Invalid slug.'}</p>;
   }
   if (!check.available) {
-    return <p className="wizard-folder-error">{check.reason ?? "Already taken."}</p>;
+    return <p className="wizard-folder-error">{check.reason ?? 'Already taken.'}</p>;
   }
   return (
     <p className="wizard-folder-ok">
@@ -356,17 +365,14 @@ function FolderHint({
 
 function WizardSteps({ current }: { current: Step }) {
   const steps: { key: Step; label: string }[] = [
-    { key: "identity", label: "1. Identity" },
-    { key: "vault", label: "2. Vault" },
-    { key: "confirm", label: "3. Confirm" },
+    { key: 'identity', label: '1. Identity' },
+    { key: 'vault', label: '2. Vault' },
+    { key: 'confirm', label: '3. Confirm' },
   ];
   return (
     <ol className="wizard-steps">
       {steps.map((s) => (
-        <li
-          key={s.key}
-          className={`wizard-step${s.key === current ? " active" : ""}`}
-        >
+        <li key={s.key} className={`wizard-step${s.key === current ? ' active' : ''}`}>
           {s.label}
         </li>
       ))}

--- a/web/ui/vite.config.ts
+++ b/web/ui/vite.config.ts
@@ -1,19 +1,33 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+// Per parachute-patterns/patterns/mount-path-convention.md: the canonical
+// production deployment is under the Parachute hub at `/claw/`, so the
+// build default IS the canonical mount. Override with `VITE_BASE_PATH=/`
+// for the legacy stand-alone shape (UI served at the origin root). The
+// previous default of `/` silently shipped root-relative asset URLs that
+// 404'd under the hub mount — see #25.
+const basePath = normalizeBase(process.env.VITE_BASE_PATH ?? "/claw/");
+
+function normalizeBase(input: string): string {
+  let b = input.startsWith("/") ? input : `/${input}`;
+  if (!b.endsWith("/")) b += "/";
+  return b;
+}
+
 export default defineConfig({
-  // Default: served at the server's root (paraclaw runs standalone on a
-  // dedicated port — UI at `/`, API at `/api/*`). Override via
-  // `VITE_BASE_PATH=/claw/ pnpm build` when serving under the Parachute hub
-  // at `https://<host>/claw/` (matches the parachute-notes mount pattern).
-  base: process.env.VITE_BASE_PATH ?? "/",
+  base: basePath,
   plugins: [react()],
   server: {
     port: 5173,
     proxy: {
-      "/api": {
+      // The dev server now serves under `/claw/` to match the production
+      // mount; the proxy strips that prefix when forwarding to the Node
+      // backend (which sees bare `/api/*` paths).
+      "/claw/api": {
         target: process.env.PARACLAW_WEB_SERVER_URL ?? "http://127.0.0.1:1944",
         changeOrigin: true,
+        rewrite: (p) => p.replace(/^\/claw/, ""),
       },
     },
   },


### PR DESCRIPTION
## Summary

Two operator papercuts on Paraclaw, bundled by user-visible feature:

1. **Control-plane "+ New session" button (#23)** — first-class way to start an agent session from the web UI. Previously the only way to wake an agent was to fire a message at the channel; the empty-state was a dead end.
2. **Vite base default = `/claw/` (#25)** — production builds that omitted `VITE_BASE_PATH` shipped root-relative asset URLs, producing a white screen on hard-refresh under the hub mount. The default now matches the canonical mount per [`mount-path-convention.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/mount-path-convention.md).

## Stack position

This PR is the head of the open stack. **Base: `feat/multi-vault-picker` (#24)**, not `main`. Stack order, oldest first: #16 → #17 → #19 → #20 → #21 → #24 → **#26**. Every prior fix in the stack is load-bearing for #26's smoke (mount-strip, basename trim, mount-aware API_BASE, startCmd→tsx, PARACHUTE_HUB_ORIGIN env). Originally branched off `main` and rebased after the team-lead flagged stack discipline.

## What changed (this PR's three commits, on top of the stack)

**`feat(server): POST /api/groups/:folder/sessions`** — calls `resolveSession(group.id, null, null, 'agent-shared')` then fires `wakeContainer(session)` (fire-and-forget — the API doesn't block on container readiness). Returns `202` + `{ sessionId, created }`. Bumps `web/server` → `0.0.13-rc.1`.

**`feat(ui): "+ New session" button`** — `spawnSession(folder)` in `lib/api.ts`; `GroupDetail` renders the button in the StatusSection header (label flips to "Spawning…" while in-flight). On success `reload()` runs immediately so the row appears before the next 7s poll tick. Empty-state copy: "No sessions yet — spawn one with the button above to start the agent's container."

**`fix(ui): vite base default = /claw/` (closes #25)** — `vite.config.ts` `base` default flipped `/` → `/claw/` per pattern; `normalizeBase()` enforces leading + trailing slash on overrides; dev proxy keys on `/claw/api` and strips `/claw` before forwarding to bare `/api/*`; new `web/ui/scripts/verify-base.mjs` is a build-time regression check that fails the build if `dist/index.html` lacks `/claw/`-prefixed asset URLs (wired into the `build` script). Bumps `web/ui` → `0.0.15-rc.1`.

## Smoke (rebased branch, against bun-linked checkout, tailnet exposure live)

| gate | result |
|---|---|
| `pnpm test` | 248/28 passed (+12 tests vs. pre-rebase from stack) |
| `pnpm typecheck` (root + web/ui + web/server) | clean |
| `npm run build` (web/ui) | clean; `verify-base: ✓ dist/index.html references /claw/-prefixed assets.` |
| `curl https://parachute.taildf9ce2.ts.net/claw/` | bundle served with `<script src="/claw/assets/...">`, no white-screen vector |
| `POST /claw/api/groups/techne/sessions` over **tailnet** (operator JWT) | `HTTP/2 202 {"sessionId":"sess-...","created":false}` (mount-strip in stack PR #19 routes correctly) |
| `GET /claw/api/groups/techne` over tailnet | `sessionCount: 1`, session in `sessions[]` |
| `POST` again (idempotent) | `202 {sessionId same, created:false}` |
| `POST` invalid folder | `404 {"error":"agent group not found: nonexistent"}` |
| `POST` no auth | `401 + WWW-Authenticate: Bearer` |
| Server log on POST | `Spawning container` fired (wakeContainer dispatched fire-and-forget) |

**Container actually starts**: not validated end-to-end here — Aaron's local OneCLI cred is failing (`401` from `app.onecli.sh/api/agents`), so the spawned container exits with code 125 before reaching ready. That's an environmental credential issue, not a regression in this PR; the `wakeContainer` call _does_ fire (logs confirm), the session row _does_ persist, and the 202 response shape is correct. A working OneCLI cred should produce a running container within ~7s of click.

**Browser click**: this PR's full smoke needs Aaron in a real browser — I can verify the wire (API + bundle + auth gate) but can't synthesize a React click. Specifically worth eyeballing:
- The button click fires the POST and the flash message renders correctly with the returned `sessionId`.
- The new session appears in the live-status table within the next 7s poll tick.
- Hard-refreshing `/claw/` deep links no longer white-screens (this is the #25 fix in action).

## Test plan

- [ ] Aaron opens `https://parachute.taildf9ce2.ts.net/claw/`, hard-refreshes — page renders (no white screen)
- [ ] Aaron opens a group, clicks "+ New session" — flash appears with new sessionId
- [ ] Within ~7s, the new session row appears in live status; container goes `running` (assuming OneCLI creds resolve)
- [ ] Click "+ New session" twice in a row — second click flashes "already exists — waking container…"

🤖 Generated with [Claude Code](https://claude.com/claude-code)