### PR TITLE
feat(secrets): selective-mode assignments + 4 endpoints

### DIFF
--- a/src/db/migrations/016-secret-assignments.ts
+++ b/src/db/migrations/016-secret-assignments.ts
@@ -1,0 +1,30 @@
+/**
+ * Selective-mode enforcement: a secret with `assigned_mode = 'selective'`
+ * is injected only into agent groups with an explicit row here. `'all'`-mode
+ * secrets ignore this table entirely (current resolveInjectableSecrets
+ * behaviour). The composite PK keeps assignments idempotent — re-assigning
+ * is a no-op rather than a duplicate row.
+ *
+ * ON DELETE CASCADE on both FKs: when a secret or agent group is deleted,
+ * its assignments evaporate. There's no soft-delete / audit row here — the
+ * activity log (PR2) is the audit surface.
+ */
+import type { Database } from '../connection.js';
+import type { Migration } from './index.js';
+
+export const migration016: Migration = {
+  version: 16,
+  name: 'secret-assignments',
+  up(db: Database) {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS secret_assignments (
+        secret_id      TEXT NOT NULL REFERENCES secrets(id) ON DELETE CASCADE,
+        agent_group_id TEXT NOT NULL REFERENCES agent_groups(id) ON DELETE CASCADE,
+        created_at     TEXT NOT NULL,
+        PRIMARY KEY (secret_id, agent_group_id)
+      );
+      CREATE INDEX IF NOT EXISTS idx_secret_assignments_agent_group
+        ON secret_assignments(agent_group_id);
+    `);
+  },
+};

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -12,6 +12,7 @@ import { migration012 } from './012-channel-registration.js';
 import { migration013 } from './013-approval-render-metadata.js';
 import { migration014 } from './014-secrets.js';
 import { migration015 } from './015-secrets-drop-host-pattern.js';
+import { migration016 } from './016-secret-assignments.js';
 import { moduleApprovalsPendingApprovals } from './module-approvals-pending-approvals.js';
 import { moduleApprovalsTitleOptions } from './module-approvals-title-options.js';
 
@@ -35,6 +36,7 @@ const migrations: Migration[] = [
   migration013,
   migration014,
   migration015,
+  migration016,
 ];
 
 export function runMigrations(db: Database): void {

--- a/src/secrets/index.ts
+++ b/src/secrets/index.ts
@@ -164,23 +164,95 @@ export function deleteSecret(id: string): boolean {
  * Resolve the secrets that should be injected into a session for the given
  * agent group. Returns plaintext values; callers are expected to inject as
  * env vars and never log. Agent-scoped wins over global on name collision.
+ *
+ * Mode semantics:
+ *   - `all`       — inject if scope matches (scoped row → its own group;
+ *                   global row → every group). Default behaviour.
+ *   - `selective` — inject only when an explicit `secret_assignments` row
+ *                   names this agent group. Lets operators stage a credential
+ *                   in the store before any agent gets it (and revoke per-
+ *                   agent without rotating the value).
  */
 export function resolveInjectableSecrets(agentGroupId: string): Map<string, string> {
   const key = secretsKey();
   const rows = db()
     .prepare<RawRow>(
-      `SELECT * FROM secrets
-       WHERE agent_group_id = @agent_group_id
-          OR agent_group_id IS NULL
-       ORDER BY agent_group_id IS NULL`,
+      `SELECT s.*
+         FROM secrets s
+         LEFT JOIN secret_assignments a
+           ON a.secret_id = s.id
+          AND a.agent_group_id = @agent_group_id
+        WHERE (s.agent_group_id = @agent_group_id OR s.agent_group_id IS NULL)
+          AND (s.assigned_mode = 'all' OR a.secret_id IS NOT NULL)
+        ORDER BY s.agent_group_id IS NULL`,
     )
     .all({ agent_group_id: agentGroupId });
 
   const out = new Map<string, string>();
   for (const row of rows) {
-    if (row.assigned_mode !== 'all') continue;
     if (out.has(row.name)) continue;
     out.set(row.name, decryptSecret(row.value_encrypted, key));
   }
   return out;
+}
+
+// ── Assignments ──
+
+export interface SecretAssignment {
+  secret_id: string;
+  agent_group_id: string;
+  created_at: string;
+}
+
+/** All agent_group_ids assigned to this secret (selective-mode allowlist). */
+export function listAssignments(secretId: string): string[] {
+  const rows = db()
+    .prepare<{ agent_group_id: string }>(
+      `SELECT agent_group_id FROM secret_assignments
+         WHERE secret_id = @secret_id
+         ORDER BY agent_group_id`,
+    )
+    .all({ secret_id: secretId });
+  return rows.map((r) => r.agent_group_id);
+}
+
+/**
+ * Replace the assignment set atomically. Empty array = revoke everything.
+ * Throws if the secret doesn't exist; FK ON DELETE CASCADE handles agent
+ * groups that vanish. The whole replace runs inside one transaction so
+ * the UI's "save" button is all-or-nothing.
+ */
+export function replaceAssignments(secretId: string, agentGroupIds: string[]): void {
+  const exists = db().prepare<{ id: string }>(`SELECT id FROM secrets WHERE id = @id`).get({ id: secretId });
+  if (!exists) throw new Error(`secret not found: ${secretId}`);
+  const now = nowIso();
+  db().transaction(() => {
+    db().prepare(`DELETE FROM secret_assignments WHERE secret_id = @secret_id`).run({ secret_id: secretId });
+    const insert = db().prepare(
+      `INSERT INTO secret_assignments (secret_id, agent_group_id, created_at)
+         VALUES (@secret_id, @agent_group_id, @created_at)`,
+    );
+    for (const gid of agentGroupIds) {
+      insert.run({ secret_id: secretId, agent_group_id: gid, created_at: now });
+    }
+  })();
+}
+
+/** Idempotent — re-adding an existing assignment is a no-op (composite PK). */
+export function addAssignment(secretId: string, agentGroupId: string): boolean {
+  const r = db()
+    .prepare(
+      `INSERT INTO secret_assignments (secret_id, agent_group_id, created_at)
+         VALUES (@secret_id, @agent_group_id, @created_at)
+         ON CONFLICT (secret_id, agent_group_id) DO NOTHING`,
+    )
+    .run({ secret_id: secretId, agent_group_id: agentGroupId, created_at: nowIso() });
+  return r.changes > 0;
+}
+
+export function removeAssignment(secretId: string, agentGroupId: string): boolean {
+  const r = db()
+    .prepare(`DELETE FROM secret_assignments WHERE secret_id = @secret_id AND agent_group_id = @agent_group_id`)
+    .run({ secret_id: secretId, agent_group_id: agentGroupId });
+  return r.changes > 0;
 }

--- a/src/secrets/secrets.test.ts
+++ b/src/secrets/secrets.test.ts
@@ -3,7 +3,17 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { closeDb, initTestDb, runMigrations } from '../db/index.js';
 import { _setMasterKeyForTest } from './master-key.js';
-import { deleteSecret, getSecret, listSecrets, putSecret, resolveInjectableSecrets } from './index.js';
+import {
+  addAssignment,
+  deleteSecret,
+  getSecret,
+  listAssignments,
+  listSecrets,
+  putSecret,
+  removeAssignment,
+  replaceAssignments,
+  resolveInjectableSecrets,
+} from './index.js';
 
 beforeEach(() => {
   const db = initTestDb();
@@ -107,5 +117,88 @@ describe('secrets store', () => {
     const env = resolveInjectableSecrets('g1');
     expect(env.has('OPT_IN')).toBe(false);
     expect(env.has('AUTO')).toBe(true);
+  });
+});
+
+describe('secret assignments (selective mode)', () => {
+  it('round-trips: selective secret with assignment to A injects into A, not B', () => {
+    const db = initTestDb();
+    runMigrations(db);
+    _setMasterKeyForTest(crypto.randomBytes(32));
+    seedAgentGroup(db, 'A');
+    seedAgentGroup(db, 'B');
+
+    const secretId = putSecret('SHARED_KEY', 'top-secret', { assigned_mode: 'selective' });
+    addAssignment(secretId, 'A');
+
+    expect(resolveInjectableSecrets('A').get('SHARED_KEY')).toBe('top-secret');
+    expect(resolveInjectableSecrets('B').has('SHARED_KEY')).toBe(false);
+  });
+
+  it('list/replace/add/remove cycle', () => {
+    const db = initTestDb();
+    runMigrations(db);
+    _setMasterKeyForTest(crypto.randomBytes(32));
+    seedAgentGroup(db, 'A');
+    seedAgentGroup(db, 'B');
+    seedAgentGroup(db, 'C');
+
+    const id = putSecret('K', 'v', { assigned_mode: 'selective' });
+    expect(listAssignments(id)).toEqual([]);
+
+    replaceAssignments(id, ['A', 'B']);
+    expect(listAssignments(id)).toEqual(['A', 'B']);
+
+    addAssignment(id, 'C');
+    expect(listAssignments(id)).toEqual(['A', 'B', 'C']);
+
+    // re-add is a no-op (composite PK)
+    expect(addAssignment(id, 'C')).toBe(false);
+
+    removeAssignment(id, 'A');
+    expect(listAssignments(id)).toEqual(['B', 'C']);
+
+    replaceAssignments(id, []);
+    expect(listAssignments(id)).toEqual([]);
+  });
+
+  it('replaceAssignments throws on unknown secret', () => {
+    const db = initTestDb();
+    runMigrations(db);
+    _setMasterKeyForTest(crypto.randomBytes(32));
+    expect(() => replaceAssignments('does-not-exist', [])).toThrow(/secret not found/);
+  });
+
+  it('deleting a secret cascades its assignments', () => {
+    const db = initTestDb();
+    runMigrations(db);
+    _setMasterKeyForTest(crypto.randomBytes(32));
+    seedAgentGroup(db, 'A');
+
+    const id = putSecret('K', 'v', { assigned_mode: 'selective' });
+    addAssignment(id, 'A');
+    expect(listAssignments(id)).toEqual(['A']);
+
+    deleteSecret(id);
+
+    const remaining = db.prepare<{ n: number }>(`SELECT COUNT(*) AS n FROM secret_assignments`).get();
+    expect(remaining?.n).toBe(0);
+  });
+
+  it('selective + assignment lets agent-scoped secrets coexist via name', () => {
+    const db = initTestDb();
+    runMigrations(db);
+    _setMasterKeyForTest(crypto.randomBytes(32));
+    seedAgentGroup(db, 'A');
+    seedAgentGroup(db, 'B');
+
+    // Global selective with assignment to A only.
+    const globalId = putSecret('TOKEN', 'shared-via-allowlist', { assigned_mode: 'selective' });
+    addAssignment(globalId, 'A');
+    // Scoped-to-B (mode: all) — different value, only B sees it.
+    putSecret('TOKEN', 'b-only', { agent_group_id: 'B' });
+
+    expect(resolveInjectableSecrets('A').get('TOKEN')).toBe('shared-via-allowlist');
+    expect(resolveInjectableSecrets('B').get('TOKEN')).toBe('b-only');
   });
 });

--- a/src/web/routes/secrets.ts
+++ b/src/web/routes/secrets.ts
@@ -13,9 +13,13 @@ import {
   type AssignedMode,
   type SecretKind,
   type SecretRow,
+  addAssignment,
   deleteSecret,
+  listAssignments,
   listSecrets,
   putSecret,
+  removeAssignment,
+  replaceAssignments,
 } from '../../secrets/index.js';
 
 const ALLOWED_KINDS: SecretKind[] = ['channel-token', 'api-key', 'generic'];
@@ -140,6 +144,74 @@ export async function handleSecretsRoute(ctx: SecretsRouteContext): Promise<bool
     }
     json(res, 200, { secret: toView(view) });
     return true;
+  }
+
+  // Assignments — match before the bare /:id DELETE so the more-specific path wins.
+  const assignOne = pathname.match(/^\/api\/secrets\/([^/]+)\/assignments\/([^/]+)$/);
+  if (assignOne && method === 'DELETE') {
+    const secretId = decodeURIComponent(assignOne[1]);
+    const groupId = decodeURIComponent(assignOne[2]);
+    const ok = removeAssignment(secretId, groupId);
+    if (!ok) {
+      error(res, 404, `assignment not found: ${secretId} -> ${groupId}`);
+      return true;
+    }
+    json(res, 200, { secretId, agentGroupId: groupId, removed: true });
+    return true;
+  }
+
+  const assignList = pathname.match(/^\/api\/secrets\/([^/]+)\/assignments$/);
+  if (assignList) {
+    const secretId = decodeURIComponent(assignList[1]);
+    if (method === 'GET') {
+      json(res, 200, { secretId, agentGroupIds: listAssignments(secretId) });
+      return true;
+    }
+    if (method === 'PUT') {
+      let body: { agentGroupIds?: unknown };
+      try {
+        body = await readJsonBody<{ agentGroupIds?: unknown }>(req);
+      } catch {
+        error(res, 400, 'invalid JSON body');
+        return true;
+      }
+      const ids = body.agentGroupIds;
+      if (!Array.isArray(ids) || !ids.every((x) => typeof x === 'string')) {
+        error(res, 400, 'agentGroupIds must be a string[]');
+        return true;
+      }
+      try {
+        replaceAssignments(secretId, ids as string[]);
+      } catch (err) {
+        error(res, 404, err instanceof Error ? err.message : String(err));
+        return true;
+      }
+      json(res, 200, { secretId, agentGroupIds: listAssignments(secretId) });
+      return true;
+    }
+    if (method === 'POST') {
+      let body: { agentGroupId?: unknown };
+      try {
+        body = await readJsonBody<{ agentGroupId?: unknown }>(req);
+      } catch {
+        error(res, 400, 'invalid JSON body');
+        return true;
+      }
+      if (typeof body.agentGroupId !== 'string' || !body.agentGroupId.trim()) {
+        error(res, 400, 'agentGroupId is required');
+        return true;
+      }
+      try {
+        addAssignment(secretId, body.agentGroupId);
+      } catch (err) {
+        // Likely a FK violation (unknown secret_id or agent_group_id).
+        // Return 400 rather than 500 so the UI can surface a clean message.
+        error(res, 400, err instanceof Error ? err.message : String(err));
+        return true;
+      }
+      json(res, 201, { secretId, agentGroupId: body.agentGroupId, added: true });
+      return true;
+    }
   }
 
   const del = pathname.match(/^\/api\/secrets\/([^/]+)$/);


### PR DESCRIPTION
## Summary
- Schema 016 adds `secret_assignments(secret_id, agent_group_id)` join table for selective-mode enforcement.
- `resolveInjectableSecrets` rewritten with a LEFT JOIN: `selective` rows inject only when there's an assignment for the spawning agent group; `all` rows ignore the table (current behaviour preserved).
- 4 endpoints under `/api/secrets/:id/assignments` — GET (list), PUT (atomic replace), POST (idempotent add), DELETE (remove). All gated `claw:admin` for mutations because reassigning re-routes a credential.

## What didn't change
- Plaintext values still never leave via any GET; the new endpoints return ids only.
- `all`-mode behaviour unchanged — existing fixtures still pass.

## Test plan
- [x] `pnpm test` — 266/266 pass (added 5 round-trip tests around assignments + selective mode).
- [x] `pnpm exec tsc --noEmit` — clean.
- [ ] Smoke: spawn paraclaw, hit the new endpoints with a forged JWT, verify a selective secret + assignment to group A injects only into A's container env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)