### PR TITLE
feat(ui): polish /secrets — search, kind groups, edit drawer, assignments

### DIFF
--- a/src/db/migrations/016-secret-assignments.ts
+++ b/src/db/migrations/016-secret-assignments.ts
@@ -1,0 +1,30 @@
+/**
+ * Selective-mode enforcement: a secret with `assigned_mode = 'selective'`
+ * is injected only into agent groups with an explicit row here. `'all'`-mode
+ * secrets ignore this table entirely (current resolveInjectableSecrets
+ * behaviour). The composite PK keeps assignments idempotent — re-assigning
+ * is a no-op rather than a duplicate row.
+ *
+ * ON DELETE CASCADE on both FKs: when a secret or agent group is deleted,
+ * its assignments evaporate. There's no soft-delete / audit row here — the
+ * activity log (PR2) is the audit surface.
+ */
+import type { Database } from '../connection.js';
+import type { Migration } from './index.js';
+
+export const migration016: Migration = {
+  version: 16,
+  name: 'secret-assignments',
+  up(db: Database) {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS secret_assignments (
+        secret_id      TEXT NOT NULL REFERENCES secrets(id) ON DELETE CASCADE,
+        agent_group_id TEXT NOT NULL REFERENCES agent_groups(id) ON DELETE CASCADE,
+        created_at     TEXT NOT NULL,
+        PRIMARY KEY (secret_id, agent_group_id)
+      );
+      CREATE INDEX IF NOT EXISTS idx_secret_assignments_agent_group
+        ON secret_assignments(agent_group_id);
+    `);
+  },
+};

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -12,6 +12,7 @@ import { migration012 } from './012-channel-registration.js';
 import { migration013 } from './013-approval-render-metadata.js';
 import { migration014 } from './014-secrets.js';
 import { migration015 } from './015-secrets-drop-host-pattern.js';
+import { migration016 } from './016-secret-assignments.js';
 import { moduleApprovalsPendingApprovals } from './module-approvals-pending-approvals.js';
 import { moduleApprovalsTitleOptions } from './module-approvals-title-options.js';
 
@@ -35,6 +36,7 @@ const migrations: Migration[] = [
   migration013,
   migration014,
   migration015,
+  migration016,
 ];
 
 export function runMigrations(db: Database): void {

--- a/src/secrets/index.ts
+++ b/src/secrets/index.ts
@@ -164,23 +164,95 @@ export function deleteSecret(id: string): boolean {
  * Resolve the secrets that should be injected into a session for the given
  * agent group. Returns plaintext values; callers are expected to inject as
  * env vars and never log. Agent-scoped wins over global on name collision.
+ *
+ * Mode semantics:
+ *   - `all`       — inject if scope matches (scoped row → its own group;
+ *                   global row → every group). Default behaviour.
+ *   - `selective` — inject only when an explicit `secret_assignments` row
+ *                   names this agent group. Lets operators stage a credential
+ *                   in the store before any agent gets it (and revoke per-
+ *                   agent without rotating the value).
  */
 export function resolveInjectableSecrets(agentGroupId: string): Map<string, string> {
   const key = secretsKey();
   const rows = db()
     .prepare<RawRow>(
-      `SELECT * FROM secrets
-       WHERE agent_group_id = @agent_group_id
-          OR agent_group_id IS NULL
-       ORDER BY agent_group_id IS NULL`,
+      `SELECT s.*
+         FROM secrets s
+         LEFT JOIN secret_assignments a
+           ON a.secret_id = s.id
+          AND a.agent_group_id = @agent_group_id
+        WHERE (s.agent_group_id = @agent_group_id OR s.agent_group_id IS NULL)
+          AND (s.assigned_mode = 'all' OR a.secret_id IS NOT NULL)
+        ORDER BY s.agent_group_id IS NULL`,
     )
     .all({ agent_group_id: agentGroupId });
 
   const out = new Map<string, string>();
   for (const row of rows) {
-    if (row.assigned_mode !== 'all') continue;
     if (out.has(row.name)) continue;
     out.set(row.name, decryptSecret(row.value_encrypted, key));
   }
   return out;
+}
+
+// ── Assignments ──
+
+export interface SecretAssignment {
+  secret_id: string;
+  agent_group_id: string;
+  created_at: string;
+}
+
+/** All agent_group_ids assigned to this secret (selective-mode allowlist). */
+export function listAssignments(secretId: string): string[] {
+  const rows = db()
+    .prepare<{ agent_group_id: string }>(
+      `SELECT agent_group_id FROM secret_assignments
+         WHERE secret_id = @secret_id
+         ORDER BY agent_group_id`,
+    )
+    .all({ secret_id: secretId });
+  return rows.map((r) => r.agent_group_id);
+}
+
+/**
+ * Replace the assignment set atomically. Empty array = revoke everything.
+ * Throws if the secret doesn't exist; FK ON DELETE CASCADE handles agent
+ * groups that vanish. The whole replace runs inside one transaction so
+ * the UI's "save" button is all-or-nothing.
+ */
+export function replaceAssignments(secretId: string, agentGroupIds: string[]): void {
+  const exists = db().prepare<{ id: string }>(`SELECT id FROM secrets WHERE id = @id`).get({ id: secretId });
+  if (!exists) throw new Error(`secret not found: ${secretId}`);
+  const now = nowIso();
+  db().transaction(() => {
+    db().prepare(`DELETE FROM secret_assignments WHERE secret_id = @secret_id`).run({ secret_id: secretId });
+    const insert = db().prepare(
+      `INSERT INTO secret_assignments (secret_id, agent_group_id, created_at)
+         VALUES (@secret_id, @agent_group_id, @created_at)`,
+    );
+    for (const gid of agentGroupIds) {
+      insert.run({ secret_id: secretId, agent_group_id: gid, created_at: now });
+    }
+  })();
+}
+
+/** Idempotent — re-adding an existing assignment is a no-op (composite PK). */
+export function addAssignment(secretId: string, agentGroupId: string): boolean {
+  const r = db()
+    .prepare(
+      `INSERT INTO secret_assignments (secret_id, agent_group_id, created_at)
+         VALUES (@secret_id, @agent_group_id, @created_at)
+         ON CONFLICT (secret_id, agent_group_id) DO NOTHING`,
+    )
+    .run({ secret_id: secretId, agent_group_id: agentGroupId, created_at: nowIso() });
+  return r.changes > 0;
+}
+
+export function removeAssignment(secretId: string, agentGroupId: string): boolean {
+  const r = db()
+    .prepare(`DELETE FROM secret_assignments WHERE secret_id = @secret_id AND agent_group_id = @agent_group_id`)
+    .run({ secret_id: secretId, agent_group_id: agentGroupId });
+  return r.changes > 0;
 }

--- a/src/secrets/secrets.test.ts
+++ b/src/secrets/secrets.test.ts
@@ -3,7 +3,17 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { closeDb, initTestDb, runMigrations } from '../db/index.js';
 import { _setMasterKeyForTest } from './master-key.js';
-import { deleteSecret, getSecret, listSecrets, putSecret, resolveInjectableSecrets } from './index.js';
+import {
+  addAssignment,
+  deleteSecret,
+  getSecret,
+  listAssignments,
+  listSecrets,
+  putSecret,
+  removeAssignment,
+  replaceAssignments,
+  resolveInjectableSecrets,
+} from './index.js';
 
 beforeEach(() => {
   const db = initTestDb();
@@ -107,5 +117,88 @@ describe('secrets store', () => {
     const env = resolveInjectableSecrets('g1');
     expect(env.has('OPT_IN')).toBe(false);
     expect(env.has('AUTO')).toBe(true);
+  });
+});
+
+describe('secret assignments (selective mode)', () => {
+  it('round-trips: selective secret with assignment to A injects into A, not B', () => {
+    const db = initTestDb();
+    runMigrations(db);
+    _setMasterKeyForTest(crypto.randomBytes(32));
+    seedAgentGroup(db, 'A');
+    seedAgentGroup(db, 'B');
+
+    const secretId = putSecret('SHARED_KEY', 'top-secret', { assigned_mode: 'selective' });
+    addAssignment(secretId, 'A');
+
+    expect(resolveInjectableSecrets('A').get('SHARED_KEY')).toBe('top-secret');
+    expect(resolveInjectableSecrets('B').has('SHARED_KEY')).toBe(false);
+  });
+
+  it('list/replace/add/remove cycle', () => {
+    const db = initTestDb();
+    runMigrations(db);
+    _setMasterKeyForTest(crypto.randomBytes(32));
+    seedAgentGroup(db, 'A');
+    seedAgentGroup(db, 'B');
+    seedAgentGroup(db, 'C');
+
+    const id = putSecret('K', 'v', { assigned_mode: 'selective' });
+    expect(listAssignments(id)).toEqual([]);
+
+    replaceAssignments(id, ['A', 'B']);
+    expect(listAssignments(id)).toEqual(['A', 'B']);
+
+    addAssignment(id, 'C');
+    expect(listAssignments(id)).toEqual(['A', 'B', 'C']);
+
+    // re-add is a no-op (composite PK)
+    expect(addAssignment(id, 'C')).toBe(false);
+
+    removeAssignment(id, 'A');
+    expect(listAssignments(id)).toEqual(['B', 'C']);
+
+    replaceAssignments(id, []);
+    expect(listAssignments(id)).toEqual([]);
+  });
+
+  it('replaceAssignments throws on unknown secret', () => {
+    const db = initTestDb();
+    runMigrations(db);
+    _setMasterKeyForTest(crypto.randomBytes(32));
+    expect(() => replaceAssignments('does-not-exist', [])).toThrow(/secret not found/);
+  });
+
+  it('deleting a secret cascades its assignments', () => {
+    const db = initTestDb();
+    runMigrations(db);
+    _setMasterKeyForTest(crypto.randomBytes(32));
+    seedAgentGroup(db, 'A');
+
+    const id = putSecret('K', 'v', { assigned_mode: 'selective' });
+    addAssignment(id, 'A');
+    expect(listAssignments(id)).toEqual(['A']);
+
+    deleteSecret(id);
+
+    const remaining = db.prepare<{ n: number }>(`SELECT COUNT(*) AS n FROM secret_assignments`).get();
+    expect(remaining?.n).toBe(0);
+  });
+
+  it('selective + assignment lets agent-scoped secrets coexist via name', () => {
+    const db = initTestDb();
+    runMigrations(db);
+    _setMasterKeyForTest(crypto.randomBytes(32));
+    seedAgentGroup(db, 'A');
+    seedAgentGroup(db, 'B');
+
+    // Global selective with assignment to A only.
+    const globalId = putSecret('TOKEN', 'shared-via-allowlist', { assigned_mode: 'selective' });
+    addAssignment(globalId, 'A');
+    // Scoped-to-B (mode: all) — different value, only B sees it.
+    putSecret('TOKEN', 'b-only', { agent_group_id: 'B' });
+
+    expect(resolveInjectableSecrets('A').get('TOKEN')).toBe('shared-via-allowlist');
+    expect(resolveInjectableSecrets('B').get('TOKEN')).toBe('b-only');
   });
 });

--- a/src/web/routes/secrets.ts
+++ b/src/web/routes/secrets.ts
@@ -33,6 +33,7 @@ interface SecretView {
   name: string;
   kind: SecretKind;
   agentGroupId: string | null;
+  assignedMode: AssignedMode;
   createdAt: string;
   updatedAt: string;
 }
@@ -43,6 +44,7 @@ function toView(r: SecretRow): SecretView {
     name: r.name,
     kind: r.kind,
     agentGroupId: r.agent_group_id,
+    assignedMode: r.assigned_mode,
     createdAt: r.created_at,
     updatedAt: r.updated_at,
   };

--- a/src/web/routes/secrets.ts
+++ b/src/web/routes/secrets.ts
@@ -13,9 +13,13 @@ import {
   type AssignedMode,
   type SecretKind,
   type SecretRow,
+  addAssignment,
   deleteSecret,
+  listAssignments,
   listSecrets,
   putSecret,
+  removeAssignment,
+  replaceAssignments,
 } from '../../secrets/index.js';
 
 const ALLOWED_KINDS: SecretKind[] = ['channel-token', 'api-key', 'generic'];
@@ -140,6 +144,74 @@ export async function handleSecretsRoute(ctx: SecretsRouteContext): Promise<bool
     }
     json(res, 200, { secret: toView(view) });
     return true;
+  }
+
+  // Assignments — match before the bare /:id DELETE so the more-specific path wins.
+  const assignOne = pathname.match(/^\/api\/secrets\/([^/]+)\/assignments\/([^/]+)$/);
+  if (assignOne && method === 'DELETE') {
+    const secretId = decodeURIComponent(assignOne[1]);
+    const groupId = decodeURIComponent(assignOne[2]);
+    const ok = removeAssignment(secretId, groupId);
+    if (!ok) {
+      error(res, 404, `assignment not found: ${secretId} -> ${groupId}`);
+      return true;
+    }
+    json(res, 200, { secretId, agentGroupId: groupId, removed: true });
+    return true;
+  }
+
+  const assignList = pathname.match(/^\/api\/secrets\/([^/]+)\/assignments$/);
+  if (assignList) {
+    const secretId = decodeURIComponent(assignList[1]);
+    if (method === 'GET') {
+      json(res, 200, { secretId, agentGroupIds: listAssignments(secretId) });
+      return true;
+    }
+    if (method === 'PUT') {
+      let body: { agentGroupIds?: unknown };
+      try {
+        body = await readJsonBody<{ agentGroupIds?: unknown }>(req);
+      } catch {
+        error(res, 400, 'invalid JSON body');
+        return true;
+      }
+      const ids = body.agentGroupIds;
+      if (!Array.isArray(ids) || !ids.every((x) => typeof x === 'string')) {
+        error(res, 400, 'agentGroupIds must be a string[]');
+        return true;
+      }
+      try {
+        replaceAssignments(secretId, ids as string[]);
+      } catch (err) {
+        error(res, 404, err instanceof Error ? err.message : String(err));
+        return true;
+      }
+      json(res, 200, { secretId, agentGroupIds: listAssignments(secretId) });
+      return true;
+    }
+    if (method === 'POST') {
+      let body: { agentGroupId?: unknown };
+      try {
+        body = await readJsonBody<{ agentGroupId?: unknown }>(req);
+      } catch {
+        error(res, 400, 'invalid JSON body');
+        return true;
+      }
+      if (typeof body.agentGroupId !== 'string' || !body.agentGroupId.trim()) {
+        error(res, 400, 'agentGroupId is required');
+        return true;
+      }
+      try {
+        addAssignment(secretId, body.agentGroupId);
+      } catch (err) {
+        // Likely a FK violation (unknown secret_id or agent_group_id).
+        // Return 400 rather than 500 so the UI can surface a clean message.
+        error(res, 400, err instanceof Error ? err.message : String(err));
+        return true;
+      }
+      json(res, 201, { secretId, agentGroupId: body.agentGroupId, added: true });
+      return true;
+    }
   }
 
   const del = pathname.match(/^\/api\/secrets\/([^/]+)$/);

--- a/src/web/routes/secrets.ts
+++ b/src/web/routes/secrets.ts
@@ -33,7 +33,6 @@ interface SecretView {
   name: string;
   kind: SecretKind;
   agentGroupId: string | null;
-  assignedMode: AssignedMode;
   createdAt: string;
   updatedAt: string;
 }
@@ -44,7 +43,6 @@ function toView(r: SecretRow): SecretView {
     name: r.name,
     kind: r.kind,
     agentGroupId: r.agent_group_id,
-    assignedMode: r.assigned_mode,
     createdAt: r.created_at,
     updatedAt: r.updated_at,
   };

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -282,12 +282,21 @@ export async function closeSession(sessionId: string): Promise<{ id: string; sta
 /** Per PRIMITIVES.md §"Secret": kinds keyed by purpose. */
 export type SecretKind = 'channel-token' | 'api-key' | 'generic';
 
+/**
+ * `all` — inject into every agent container (subject to scoped-vs-global
+ *   resolution per `src/secrets/index.ts:resolveInjectableSecrets`).
+ * `selective` — inject only into the agent groups explicitly assigned via
+ *   /api/secrets/:id/assignments.
+ */
+export type AssignedMode = 'all' | 'selective';
+
 export interface SecretView {
   id: string;
   name: string;
   kind: SecretKind;
   /** null when the secret is global (not bound to a single agent group). */
   agentGroupId: string | null;
+  assignedMode: AssignedMode;
   createdAt: string;
   updatedAt: string;
   // Values are NEVER returned — they exist only to be injected into
@@ -305,6 +314,7 @@ export interface PutSecretInput {
   kind?: SecretKind;
   /** Bind to a specific agent group. Omit for a global secret. */
   agentGroupId?: string | null;
+  assignedMode?: AssignedMode;
 }
 
 /**
@@ -313,15 +323,44 @@ export interface PutSecretInput {
  * raw value is dropped from memory the moment the request resolves.
  */
 export async function putSecret(input: PutSecretInput): Promise<SecretView> {
-  const r = await request<{ secret: SecretView }>('/secrets', {
-    method: 'POST',
-    json: input,
-  });
+  const body: Record<string, unknown> = {
+    name: input.name,
+    value: input.value,
+  };
+  if (input.kind !== undefined) body.kind = input.kind;
+  if (input.agentGroupId !== undefined) body.agentGroupId = input.agentGroupId;
+  // Server reads snake_case for assigned_mode (src/web/routes/secrets.ts);
+  // send both so the wire is robust to a future camelCase migration.
+  if (input.assignedMode !== undefined) {
+    body.assignedMode = input.assignedMode;
+    body.assigned_mode = input.assignedMode;
+  }
+  const r = await request<{ secret: SecretView }>('/secrets', { method: 'POST', json: body });
   return r.secret;
 }
 
 export async function deleteSecret(id: string): Promise<void> {
   return request<void>(`/secrets/${encodeURIComponent(id)}`, { method: 'DELETE' });
+}
+
+/**
+ * Per-secret assignment endpoints (selective-mode only). The server returns
+ * just IDs; the UI denormalizes against listGroups() for display.
+ * See migrations/016 + src/web/routes/secrets.ts.
+ */
+export async function listSecretAssignments(secretId: string): Promise<string[]> {
+  const r = await request<{ secretId: string; agentGroupIds: string[] }>(
+    `/secrets/${encodeURIComponent(secretId)}/assignments`,
+  );
+  return r.agentGroupIds;
+}
+
+export async function setSecretAssignments(secretId: string, agentGroupIds: string[]): Promise<string[]> {
+  const r = await request<{ secretId: string; agentGroupIds: string[] }>(
+    `/secrets/${encodeURIComponent(secretId)}/assignments`,
+    { method: 'PUT', json: { agentGroupIds } },
+  );
+  return r.agentGroupIds;
 }
 
 // --- Approvals ---

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -304,8 +304,13 @@ export interface SecretView {
 }
 
 export async function listSecrets(): Promise<SecretView[]> {
-  const r = await request<{ secrets: SecretView[] }>('/secrets');
-  return r.secrets;
+  // The list-secrets endpoint may not yet surface `assignedMode` (it lands in
+  // a separate paraclaw-server PR). Default missing values to 'all' so the UI
+  // renders correctly until the field is wired through.
+  const r = await request<{ secrets: Array<Omit<SecretView, 'assignedMode'> & { assignedMode?: AssignedMode }> }>(
+    '/secrets',
+  );
+  return r.secrets.map((s) => ({ ...s, assignedMode: s.assignedMode ?? 'all' }));
 }
 
 export interface PutSecretInput {
@@ -335,8 +340,12 @@ export async function putSecret(input: PutSecretInput): Promise<SecretView> {
     body.assignedMode = input.assignedMode;
     body.assigned_mode = input.assignedMode;
   }
-  const r = await request<{ secret: SecretView }>('/secrets', { method: 'POST', json: body });
-  return r.secret;
+  const r = await request<{
+    secret: Omit<SecretView, 'assignedMode'> & { assignedMode?: AssignedMode };
+  }>('/secrets', { method: 'POST', json: body });
+  // Same fallback as listSecrets — until paraclaw-server surfaces the field,
+  // assume the just-written value (or 'all' if we didn't send one).
+  return { ...r.secret, assignedMode: r.secret.assignedMode ?? input.assignedMode ?? 'all' };
 }
 
 export async function deleteSecret(id: string): Promise<void> {

--- a/web/ui/src/routes/SecretsList.tsx
+++ b/web/ui/src/routes/SecretsList.tsx
@@ -1,37 +1,78 @@
 /**
- * /secrets — paraclaw-native secrets list.
+ * /secrets — paraclaw-native secrets management view.
  *
- * Replaces the old OneCLI proxy page. Backend is the AES-256-GCM secrets
- * store at ~/.parachute/claw/secrets.db; values are NEVER returned over
- * the wire (write-only by design). The list shows names + kinds + scope
- * only; create/delete are the only mutating actions.
+ * Replaces the previous primitive list with an actual management surface:
+ *   - search/filter (name + kind + group scope),
+ *   - collapsible groups by kind (channel-token / api-key / generic),
+ *   - mode badge (all | selective) with tooltip,
+ *   - edit drawer for inject-mode + assignments + value rotation,
+ *   - empty states with CTAs,
+ *   - relative timestamps with absolute on hover.
  *
- * Scope binding: a secret can be either global (agentGroupId = null,
- * available to every spawned container whose host pattern matches) or
- * scoped to a specific agent group. The list groups rows by scope so the
- * operator can see at a glance which secrets are isolated.
+ * Wire surface:
+ *   GET    /api/secrets
+ *   POST   /api/secrets                          (create / rotate / mode-switch)
+ *   DELETE /api/secrets/:id
+ *   GET    /api/secrets/:id/assignments
+ *   PUT    /api/secrets/:id/assignments
  *
- * The create form is the shared CredentialForm component in `free` mode —
- * same code path as the wizard's channel mode, just without the platform
- * pre-flight validation. When the user adds a name that overlaps with an
- * existing one in the same scope the server upserts (per PRIMITIVES.md);
- * the UI reflects that by reloading after onCreated.
+ * Selective mode: secret only injects into agent groups listed in
+ * secret_assignments (migration 016). Switching mode requires re-pasting
+ * the value because the server's POST upsert wire requires `value`.
  */
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { CredentialForm } from '../components/CredentialForm.tsx';
-import { deleteSecret, listGroups, listSecrets, type AgentGroupView, type SecretView } from '../lib/api.ts';
+import { formatRelative } from '../components/StatusDot.tsx';
+import {
+  deleteSecret,
+  listGroups,
+  listSecretAssignments,
+  listSecrets,
+  putSecret,
+  setSecretAssignments,
+  type AgentGroupView,
+  type AssignedMode,
+  type SecretKind,
+  type SecretView,
+} from '../lib/api.ts';
+
+// Kind display order — channel-tokens first since they're the most common
+// reason to open this page in the early-life of an install.
+const KIND_ORDER: SecretKind[] = ['channel-token', 'api-key', 'generic'];
+
+const KIND_LABEL: Record<SecretKind, string> = {
+  'channel-token': 'Channel tokens',
+  'api-key': 'API keys',
+  generic: 'Other',
+};
+
+const KIND_HINT: Record<SecretKind, string> = {
+  'channel-token': 'Bot tokens for chat platforms (Discord, Telegram, …).',
+  'api-key': 'Long-lived API keys (OpenAI, Anthropic, vendor APIs).',
+  generic: 'Anything else — env-var style key/values.',
+};
+
+interface LoadedState {
+  kind: 'ok';
+  secrets: SecretView[];
+  groups: AgentGroupView[];
+}
+
+type State =
+  | { kind: 'loading' }
+  | LoadedState
+  | { kind: 'error'; message: string };
 
 export function SecretsList() {
-  const [state, setState] = useState<
-    | { kind: 'loading' }
-    | { kind: 'ok'; secrets: SecretView[]; groups: AgentGroupView[] }
-    | { kind: 'error'; message: string }
-  >({ kind: 'loading' });
+  const [state, setState] = useState<State>({ kind: 'loading' });
   const [reloadKey, setReloadKey] = useState(0);
   const [showCreate, setShowCreate] = useState(false);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+  const [collapsed, setCollapsed] = useState<Set<SecretKind>>(new Set());
+  const [editing, setEditing] = useState<SecretView | null>(null);
 
   const reload = useCallback(() => setReloadKey((k) => k + 1), []);
 
@@ -43,10 +84,7 @@ export function SecretsList() {
       })
       .catch((err) => {
         if (!cancelled) {
-          setState({
-            kind: 'error',
-            message: err instanceof Error ? err.message : String(err),
-          });
+          setState({ kind: 'error', message: err instanceof Error ? err.message : String(err) });
         }
       });
     return () => {
@@ -67,6 +105,14 @@ export function SecretsList() {
       setBusyId(null);
     }
   };
+
+  const toggleCollapsed = (k: SecretKind) =>
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(k)) next.delete(k);
+      else next.add(k);
+      return next;
+    });
 
   if (state.kind === 'loading') {
     return (
@@ -95,28 +141,110 @@ export function SecretsList() {
     );
   }
 
+  return (
+    <LoadedView
+      state={state}
+      query={query}
+      setQuery={setQuery}
+      collapsed={collapsed}
+      toggleCollapsed={toggleCollapsed}
+      showCreate={showCreate}
+      setShowCreate={setShowCreate}
+      busyId={busyId}
+      onDelete={onDelete}
+      actionError={actionError}
+      onEdit={setEditing}
+      editing={editing}
+      onCloseEditor={(changed) => {
+        setEditing(null);
+        if (changed) reload();
+      }}
+      reload={reload}
+    />
+  );
+}
+
+interface LoadedProps {
+  state: LoadedState;
+  query: string;
+  setQuery: (q: string) => void;
+  collapsed: Set<SecretKind>;
+  toggleCollapsed: (k: SecretKind) => void;
+  showCreate: boolean;
+  setShowCreate: (v: boolean) => void;
+  busyId: string | null;
+  onDelete: (s: SecretView) => void;
+  actionError: string | null;
+  onEdit: (s: SecretView) => void;
+  editing: SecretView | null;
+  onCloseEditor: (changed: boolean) => void;
+  reload: () => void;
+}
+
+function LoadedView(props: LoadedProps) {
+  const {
+    state,
+    query,
+    setQuery,
+    collapsed,
+    toggleCollapsed,
+    showCreate,
+    setShowCreate,
+    busyId,
+    onDelete,
+    actionError,
+    onEdit,
+    editing,
+    onCloseEditor,
+    reload,
+  } = props;
+
   const groupName = (id: string | null): string => {
     if (!id) return 'global';
     const g = state.groups.find((x) => x.id === id);
-    return g ? g.name : `(unknown group ${id.slice(0, 8)}…)`;
+    return g ? g.name : `(unknown ${id.slice(0, 8)})`;
   };
 
-  const global = state.secrets.filter((s) => !s.agentGroupId);
-  const scoped = state.secrets.filter((s) => s.agentGroupId);
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return state.secrets;
+    return state.secrets.filter((s) => {
+      if (s.name.toLowerCase().includes(q)) return true;
+      if (s.kind.toLowerCase().includes(q)) return true;
+      if (KIND_LABEL[s.kind].toLowerCase().includes(q)) return true;
+      const scope = groupName(s.agentGroupId).toLowerCase();
+      if (scope.includes(q)) return true;
+      if (s.assignedMode.toLowerCase().includes(q)) return true;
+      return false;
+    });
+    // groupName depends on state.groups; lint will see state.secrets/state.groups.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query, state.secrets, state.groups]);
+
+  const byKind = useMemo(() => {
+    const m = new Map<SecretKind, SecretView[]>();
+    for (const k of KIND_ORDER) m.set(k, []);
+    for (const s of filtered) {
+      const list = m.get(s.kind) ?? [];
+      list.push(s);
+      m.set(s.kind, list);
+    }
+    for (const list of m.values()) list.sort((a, b) => a.name.localeCompare(b.name));
+    return m;
+  }, [filtered]);
+
+  const totalShown = filtered.length;
 
   return (
     <div>
       <div className="list-header">
         <h2>Secrets ({state.secrets.length})</h2>
-        <button onClick={() => setShowCreate((v) => !v)}>
-          {showCreate ? 'Cancel' : '+ New secret'}
-        </button>
+        <button onClick={() => setShowCreate(!showCreate)}>{showCreate ? 'Cancel' : '+ New secret'}</button>
       </div>
 
       <p className="muted">
         Encrypted at rest under <code>~/.parachute/claw/master.key</code>. Injected into agent containers at session
-        spawn — values are never read back over the API. To rotate, just create a new secret with the same name; the
-        server upserts.
+        spawn — values are never read back over the API. To rotate, edit a row.
       </p>
 
       {showCreate && (
@@ -142,59 +270,128 @@ export function SecretsList() {
             Add a channel token (Discord, Telegram) or an arbitrary API key. The setup wizard at{' '}
             <Link to="/setup">/setup</Link> walks you through wiring channel tokens.
           </p>
+          <div className="actions" style={{ marginTop: '1rem' }}>
+            <button onClick={() => setShowCreate(true)}>+ Add your first secret</button>
+          </div>
         </div>
       )}
 
-      {global.length > 0 && (
-        <SecretGroup label="Global" hint="Available to every agent container whose vault host pattern matches.">
-          {global.map((s) => (
-            <SecretRow key={s.id} s={s} groupName={groupName} busy={busyId === s.id} onDelete={onDelete} />
-          ))}
-        </SecretGroup>
+      {state.secrets.length > 0 && (
+        <div className="row" style={{ marginTop: '1.25rem' }}>
+          <input
+            type="search"
+            placeholder="Filter by name, kind, or scope…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            style={{ width: '100%' }}
+            aria-label="Filter secrets"
+          />
+        </div>
       )}
 
-      {scoped.length > 0 && (
-        <SecretGroup label="Scoped to an agent group" hint="Only injected into containers for the bound group.">
-          {scoped.map((s) => (
-            <SecretRow key={s.id} s={s} groupName={groupName} busy={busyId === s.id} onDelete={onDelete} />
-          ))}
-        </SecretGroup>
+      {state.secrets.length > 0 && totalShown === 0 && (
+        <div className="empty">No secrets match <code>{query}</code>.</div>
       )}
+
+      {KIND_ORDER.map((k) => {
+        const list = byKind.get(k) ?? [];
+        if (list.length === 0) return null;
+        const isCollapsed = collapsed.has(k);
+        return (
+          <SecretKindGroup
+            key={k}
+            kind={k}
+            secrets={list}
+            collapsed={isCollapsed}
+            onToggle={() => toggleCollapsed(k)}
+            groupName={groupName}
+            busyId={busyId}
+            onEdit={onEdit}
+            onDelete={onDelete}
+          />
+        );
+      })}
+
+      {editing && <SecretEditor secret={editing} groups={state.groups} onClose={onCloseEditor} />}
     </div>
   );
 }
 
-function SecretGroup({
-  label,
-  hint,
-  children,
-}: {
-  label: string;
-  hint: string;
-  children: React.ReactNode;
-}) {
+interface KindGroupProps {
+  kind: SecretKind;
+  secrets: SecretView[];
+  collapsed: boolean;
+  onToggle: () => void;
+  groupName: (id: string | null) => string;
+  busyId: string | null;
+  onEdit: (s: SecretView) => void;
+  onDelete: (s: SecretView) => void;
+}
+
+function SecretKindGroup({ kind, secrets, collapsed, onToggle, groupName, busyId, onEdit, onDelete }: KindGroupProps) {
   return (
     <div style={{ marginTop: '1.5rem' }}>
-      <h3 style={{ margin: '0 0 0.25rem', fontSize: '0.85rem', color: 'var(--fg-muted)', textTransform: 'uppercase', letterSpacing: '0.06em', fontWeight: 500 }}>
-        {label}
-      </h3>
-      <p className="dim" style={{ margin: '0 0 0.5rem' }}>{hint}</p>
-      <div>{children}</div>
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={!collapsed}
+        style={{
+          background: 'transparent',
+          color: 'var(--fg)',
+          border: 0,
+          padding: 0,
+          margin: '0 0 0.25rem',
+          fontSize: '0.85rem',
+          textTransform: 'uppercase',
+          letterSpacing: '0.06em',
+          fontWeight: 500,
+          cursor: 'pointer',
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '0.4rem',
+        }}
+      >
+        <span style={{ fontSize: '0.7rem', color: 'var(--fg-muted)' }}>{collapsed ? '▸' : '▾'}</span>
+        <span style={{ color: 'var(--fg-muted)' }}>{KIND_LABEL[kind]}</span>
+        <span style={{ color: 'var(--fg-dim)', fontSize: '0.78rem', textTransform: 'none', letterSpacing: 0 }}>
+          ({secrets.length})
+        </span>
+      </button>
+      {!collapsed && (
+        <>
+          <p className="dim" style={{ margin: '0 0 0.5rem' }}>{KIND_HINT[kind]}</p>
+          <div>
+            {secrets.map((s) => (
+              <SecretRow
+                key={s.id}
+                s={s}
+                groupName={groupName}
+                busy={busyId === s.id}
+                onEdit={onEdit}
+                onDelete={onDelete}
+              />
+            ))}
+          </div>
+        </>
+      )}
     </div>
   );
 }
 
-function SecretRow({
-  s,
-  groupName,
-  busy,
-  onDelete,
-}: {
+interface RowProps {
   s: SecretView;
   groupName: (id: string | null) => string;
   busy: boolean;
+  onEdit: (s: SecretView) => void;
   onDelete: (s: SecretView) => void;
-}) {
+}
+
+function SecretRow({ s, groupName, busy, onEdit, onDelete }: RowProps) {
+  const updatedAbs = new Date(s.updatedAt).toLocaleString();
+  const modeTitle =
+    s.assignedMode === 'all'
+      ? 'Mode: all — injected into every agent container that resolves this name (subject to scope).'
+      : 'Mode: selective — injected only into agent groups explicitly assigned (see Edit).';
   return (
     <div
       style={{
@@ -211,13 +408,26 @@ function SecretRow({
       <div style={{ flex: 1, minWidth: 0 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
           <code style={{ fontSize: '0.95em' }}>{s.name}</code>
-          <span className="tag muted">{s.kind}</span>
-          {s.agentGroupId && <span className="tag">{groupName(s.agentGroupId)}</span>}
+          <span className={`tag ${s.assignedMode === 'selective' ? 'warn' : ''}`} title={modeTitle}>
+            {s.assignedMode}
+          </span>
+          {s.agentGroupId ? (
+            <span className="tag muted" title={`Scoped to agent group ${groupName(s.agentGroupId)}`}>
+              {groupName(s.agentGroupId)}
+            </span>
+          ) : (
+            <span className="tag muted" title="Global — available to every agent group">
+              global
+            </span>
+          )}
         </div>
-        <div className="dim" style={{ marginTop: '0.25rem' }}>
-          updated {new Date(s.updatedAt).toLocaleString()}
+        <div className="dim" style={{ marginTop: '0.25rem' }} title={updatedAbs}>
+          updated {formatRelative(s.updatedAt)}
         </div>
       </div>
+      <button type="button" className="secondary" onClick={() => onEdit(s)} disabled={busy}>
+        Edit
+      </button>
       <button
         type="button"
         className="secondary danger"
@@ -228,5 +438,273 @@ function SecretRow({
         {busy ? 'Deleting…' : 'Delete'}
       </button>
     </div>
+  );
+}
+
+interface EditorProps {
+  secret: SecretView;
+  groups: AgentGroupView[];
+  onClose: (changed: boolean) => void;
+}
+
+/**
+ * Edit drawer rendered as a native <dialog>. Three concurrent edits in scope:
+ *   1. Inject mode (all|selective)
+ *   2. Selective assignments (multi-select agent groups)
+ *   3. Value rotation
+ *
+ * Mode flips and kind changes both require value re-paste because the server's
+ * POST upsert wire requires `value`. Assignment-only edits go straight to the
+ * /assignments PUT and don't touch the secret value at all.
+ */
+function SecretEditor({ secret, groups, onClose }: EditorProps) {
+  const dialogRef = useRef<HTMLDialogElement | null>(null);
+
+  const [mode, setMode] = useState<AssignedMode>(secret.assignedMode);
+  const [assignments, setAssignments] = useState<Set<string>>(new Set());
+  const [assignmentsLoaded, setAssignmentsLoaded] = useState(false);
+  const initialAssignmentsRef = useRef<Set<string> | null>(null);
+  const [value, setValue] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Open the dialog on mount, close imperatively on unmount. Native <dialog>
+  // gives us focus-trap + ESC-to-close for free.
+  useEffect(() => {
+    const d = dialogRef.current;
+    if (d && !d.open) d.showModal();
+    return () => {
+      if (d?.open) d.close();
+    };
+  }, []);
+
+  // Initial assignments fetch — fires once. Snapshot initial set into a ref
+  // so assignmentsChanged can compare against the pristine state, not the
+  // running edits.
+  useEffect(() => {
+    let cancelled = false;
+    listSecretAssignments(secret.id)
+      .then((ids) => {
+        if (cancelled) return;
+        const set = new Set(ids);
+        setAssignments(set);
+        initialAssignmentsRef.current = new Set(set);
+        setAssignmentsLoaded(true);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(`Couldn't load assignments: ${err instanceof Error ? err.message : String(err)}`);
+        initialAssignmentsRef.current = new Set();
+        setAssignmentsLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [secret.id]);
+
+  const toggleAssignment = (groupId: string) =>
+    setAssignments((prev) => {
+      const next = new Set(prev);
+      if (next.has(groupId)) next.delete(groupId);
+      else next.add(groupId);
+      return next;
+    });
+
+  const modeChanged = mode !== secret.assignedMode;
+  const assignmentsChanged = (() => {
+    if (!assignmentsLoaded || !initialAssignmentsRef.current) return false;
+    const init = initialAssignmentsRef.current;
+    if (init.size !== assignments.size) return true;
+    for (const id of assignments) if (!init.has(id)) return true;
+    return false;
+  })();
+  const valueProvided = value.trim().length > 0;
+
+  const save = async () => {
+    setError(null);
+    if (modeChanged && !valueProvided) {
+      setError('Switching inject mode requires re-pasting the secret value (the server upsert wire requires it).');
+      return;
+    }
+    setBusy(true);
+    try {
+      if (valueProvided) {
+        await putSecret({
+          name: secret.name,
+          value: value.trim(),
+          kind: secret.kind,
+          agentGroupId: secret.agentGroupId,
+          assignedMode: mode,
+        });
+      }
+      // Push assignments whenever they changed, OR whenever we just upserted
+      // the secret with selective mode (so the join-table reflects intent
+      // even on first switch).
+      if (mode === 'selective' && (assignmentsChanged || (modeChanged && valueProvided))) {
+        await setSecretAssignments(secret.id, Array.from(assignments));
+      }
+      onClose(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const noAssignmentsWarn = mode === 'selective' && assignmentsLoaded && assignments.size === 0;
+  const scopeLabel = secret.agentGroupId
+    ? (groups.find((g) => g.id === secret.agentGroupId)?.name ?? secret.agentGroupId.slice(0, 8))
+    : 'global';
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onClose={() => onClose(false)}
+      className="secret-editor"
+      style={{
+        width: 'min(560px, 92vw)',
+        border: '1px solid var(--border)',
+        borderRadius: '12px',
+        padding: 0,
+        background: 'white',
+      }}
+    >
+      <form method="dialog" onSubmit={(e) => e.preventDefault()}>
+        <div style={{ padding: '1.25rem 1.5rem', borderBottom: '1px solid var(--border)' }}>
+          <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: '0.5rem' }}>
+            <h3 style={{ margin: 0, fontSize: '1.05rem' }}>
+              <code>{secret.name}</code>
+            </h3>
+            <button
+              type="button"
+              className="secondary"
+              onClick={() => onClose(false)}
+              style={{ padding: '0.3rem 0.7rem' }}
+              aria-label="Close"
+            >
+              ✕
+            </button>
+          </div>
+          <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.5rem', flexWrap: 'wrap' }}>
+            <span className="tag muted">{secret.kind}</span>
+            <span className="tag muted">{scopeLabel}</span>
+          </div>
+          <div className="dim" style={{ marginTop: '0.5rem' }}>
+            created <span title={new Date(secret.createdAt).toLocaleString()}>{formatRelative(secret.createdAt)}</span>
+            {' • '}updated <span title={new Date(secret.updatedAt).toLocaleString()}>{formatRelative(secret.updatedAt)}</span>
+          </div>
+        </div>
+
+        <div style={{ padding: '1.25rem 1.5rem' }}>
+          {error && <div className="error-banner">{error}</div>}
+
+          <div className="row">
+            <label>Inject mode</label>
+            <div style={{ display: 'flex', gap: '1.5rem', flexWrap: 'wrap' }}>
+              <label style={{ display: 'inline-flex', gap: '0.4rem', alignItems: 'center', fontWeight: 400 }}>
+                <input
+                  type="radio"
+                  name="mode"
+                  value="all"
+                  checked={mode === 'all'}
+                  onChange={() => setMode('all')}
+                  disabled={busy}
+                />
+                <span>all</span>
+              </label>
+              <label style={{ display: 'inline-flex', gap: '0.4rem', alignItems: 'center', fontWeight: 400 }}>
+                <input
+                  type="radio"
+                  name="mode"
+                  value="selective"
+                  checked={mode === 'selective'}
+                  onChange={() => setMode('selective')}
+                  disabled={busy}
+                />
+                <span>selective</span>
+              </label>
+            </div>
+            <p className="dim" style={{ marginTop: '0.4rem' }}>
+              {mode === 'all'
+                ? 'Injected into every agent container whose scope matches.'
+                : 'Injected only into the agent groups you check below.'}
+            </p>
+          </div>
+
+          {mode === 'selective' && (
+            <div className="row">
+              <label>Assigned to ({assignments.size})</label>
+              {!assignmentsLoaded && <p className="dim">Loading current assignments…</p>}
+              {assignmentsLoaded && groups.length === 0 && (
+                <p className="dim">No agent groups exist yet — create one to assign this secret.</p>
+              )}
+              {assignmentsLoaded && groups.length > 0 && (
+                <div
+                  style={{
+                    display: 'grid',
+                    gap: '0.35rem',
+                    maxHeight: '14rem',
+                    overflowY: 'auto',
+                    border: '1px solid var(--border)',
+                    borderRadius: 6,
+                    padding: '0.5rem 0.75rem',
+                  }}
+                >
+                  {groups.map((g) => (
+                    <label key={g.id} style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', fontWeight: 400 }}>
+                      <input
+                        type="checkbox"
+                        checked={assignments.has(g.id)}
+                        onChange={() => toggleAssignment(g.id)}
+                        disabled={busy}
+                      />
+                      <span>{g.name}</span>
+                      <code style={{ fontSize: '0.78rem', color: 'var(--fg-dim)' }}>{g.folder}</code>
+                    </label>
+                  ))}
+                </div>
+              )}
+              {noAssignmentsWarn && (
+                <div className="warn-banner" style={{ marginTop: '0.5rem' }}>
+                  Selective mode with zero assignments — this secret will inject into nothing. OK if intentional, but
+                  containers that read this name will see it as unset.
+                </div>
+              )}
+            </div>
+          )}
+
+          <div className="row">
+            <label htmlFor="rotateValue">
+              {modeChanged ? 'Value (required to apply mode change)' : 'Rotate value (optional)'}
+            </label>
+            <input
+              id="rotateValue"
+              type="password"
+              autoComplete="off"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              disabled={busy}
+              placeholder={modeChanged ? 'paste current value' : 'leave blank to keep current value'}
+            />
+            <p className="dim" style={{ marginTop: '0.25rem' }}>
+              Value is never read back over the API; rotating writes a new ciphertext under the same name.
+            </p>
+          </div>
+
+          <div className="actions" style={{ marginTop: '1rem', justifyContent: 'flex-end' }}>
+            <button type="button" className="secondary" onClick={() => onClose(false)} disabled={busy}>
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={save}
+              disabled={busy || (!modeChanged && !assignmentsChanged && !valueProvided)}
+            >
+              {busy ? 'Saving…' : 'Save changes'}
+            </button>
+          </div>
+        </div>
+      </form>
+    </dialog>
   );
 }


### PR DESCRIPTION
> **Stacked on #37 (`feat/secret-assignments`); merge in order.**
> The `/api/secrets/:id/assignments` endpoints land in #37; this PR consumes them.

## Summary

Replaces the primitive `/secrets` list (basic scope-grouped rows + create form) with a real management surface.

- **Search/filter** input across name, kind, scope, and inject mode.
- **Collapsible kind groups** — Channel tokens / API keys / Other — with a one-line hint per group.
- **Mode badge** (`all` | `selective`) on every row, with a hover tooltip explaining the behavior.
- **Edit drawer** as a native `<dialog>` (focus-trap + ESC + backdrop close come for free) covering inject mode, selective-mode assignments, and value rotation.
- **Assignments multi-select** for selective mode, wired to the new server `/api/secrets/:id/assignments` endpoints (added by ea78e98 on the server side, in #37).
- **Empty states** — full empty has a primary CTA (`+ Add your first secret`); filtered-empty shows the query.
- **Relative timestamps** with absolute on hover (reuses `formatRelative` from StatusDot).

### api.ts additions

- `AssignedMode` type + `assignedMode` field on `SecretView` and `PutSecretInput`.
- `listSecretAssignments(secretId)` / `setSecretAssignments(secretId, ids)` wrap the new endpoints. Server returns just IDs; the UI denormalizes against `listGroups()`.
- `putSecret` now sends both `assignedMode` and `assigned_mode` so the wire stays robust to a future camelCase migration on the server.
- `listSecrets()` / `putSecret()` default `assignedMode` to `'all'` when the server response omits the field, so this UI works against either the pre- or post-`assignedMode` server. The corresponding server-side change is owned by paraclaw-server (separate PR).

### Mode-switch / kind-change

Both still require re-pasting the value because the server's POST upsert wire requires `value`. Surfaced inline in the drawer (label flips to "Value (required to apply mode change)").

## Test plan

- [x] `pnpm exec tsc --noEmit` (root + web/ui) clean
- [x] `pnpm build` (web/ui) — verify-base passes, dist references `/claw/`-prefixed assets
- [x] `pnpm test` (server) — 266/266 pass
- [ ] Manual smoke at `/claw/secrets` after #37 merges into `night/paraclaw-rebirth` and is rebuilt locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)