### PR TITLE
feat(ui): activity tab on /claw/groups/:folder

### DIFF
--- a/web/ui/src/components/ActivityFeed.tsx
+++ b/web/ui/src/components/ActivityFeed.tsx
@@ -1,0 +1,389 @@
+/**
+ * Per-agent-group activity feed. Renders the rows from
+ * `GET /api/agent-groups/:folder/activity` as an audit log — collapses runs
+ * of the same `(kind, target)` so a chatty agent that hits one tool twenty
+ * times in a row doesn't drown out the next interesting event.
+ *
+ * Three kinds get bespoke rendering per the PR2 brief:
+ *   - `secret_use`: "<secret> · used N times" with a key icon
+ *   - `mcp_call`:    "<tool> · called N times" with a wrench icon
+ *   - `cmd_exec`:    "<command>" with output preview underneath, no run-collapse
+ *                    (each command is its own thing — collapsing would lose
+ *                    the output diversity that makes this kind useful)
+ *
+ * Any other kind falls through to a plain `kind • target — summary` row.
+ */
+import { useCallback, useEffect, useState } from 'react';
+
+import { type ActivityEntry, listGroupActivity } from '../lib/api.ts';
+import { formatRelative } from './StatusDot.tsx';
+
+const POLL_MS = 15_000;
+const PAGE_SIZE = 100;
+const CMD_PREVIEW_CHARS = 140;
+
+interface ActivityFeedProps {
+  folder: string;
+}
+
+export function ActivityFeed({ folder }: ActivityFeedProps) {
+  const [items, setItems] = useState<ActivityEntry[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const reload = useCallback(async () => {
+    try {
+      const rows = await listGroupActivity(folder, { limit: PAGE_SIZE });
+      setItems(rows);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [folder]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  // Background poll — silent on failure. The 15s cadence is conservative
+  // (this is an audit log, not a chat scroll); user can refresh manually if
+  // they're watching live.
+  useEffect(() => {
+    if (error) return;
+    const t = setInterval(() => {
+      listGroupActivity(folder, { limit: PAGE_SIZE })
+        .then((rows) => setItems(rows))
+        .catch(() => {});
+    }, POLL_MS);
+    return () => clearInterval(t);
+  }, [folder, error]);
+
+  if (loading && !items) {
+    return (
+      <div className="section">
+        <div className="skeleton skeleton-line" style={{ width: '40%' }} />
+        <div className="skeleton skeleton-line" />
+        <div className="skeleton skeleton-line" style={{ width: '70%' }} />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="section">
+        <div className="error-banner">{error}</div>
+        <button onClick={() => void reload()}>Retry</button>
+      </div>
+    );
+  }
+
+  if (!items || items.length === 0) {
+    return (
+      <div className="section">
+        <div className="empty">
+          No activity yet. The agent's actions — secret reads, MCP tool calls, command
+          executions — will show up here once a session is running.
+        </div>
+      </div>
+    );
+  }
+
+  const collapsed = collapseRuns(items);
+  return (
+    <div className="section activity-feed">
+      <ul className="activity-list">
+        {collapsed.map((row) => (
+          <ActivityRow key={row.key} row={row} />
+        ))}
+      </ul>
+      {items.length >= PAGE_SIZE && (
+        <p className="dim activity-more">
+          Showing the {PAGE_SIZE} most recent events. Older history is in the agent's
+          session DBs.
+        </p>
+      )}
+    </div>
+  );
+}
+
+// --- collapse logic ---
+
+/**
+ * One rendered row. Either a single entry, or a run of consecutive entries
+ * sharing the same `(kind, target)` — the latter renders as a count badge.
+ *
+ * `cmd_exec` is intentionally NEVER run-collapsed: each command's output is
+ * unique enough that merging loses the signal.
+ */
+type Row =
+  | { type: 'single'; key: string; entry: ActivityEntry }
+  | {
+      type: 'run';
+      key: string;
+      kind: ActivityEntry['kind'];
+      target: string;
+      count: number;
+      newest: ActivityEntry;
+      oldestAt: string;
+    };
+
+function collapseRuns(items: ActivityEntry[]): Row[] {
+  // Server returns newest-first. We collapse adjacent same-(kind,target)
+  // entries — preserves chronology while compressing chatter.
+  const out: Row[] = [];
+  for (const entry of items) {
+    if (entry.kind === 'cmd_exec') {
+      out.push({ type: 'single', key: entry.id, entry });
+      continue;
+    }
+    const last = out[out.length - 1];
+    if (
+      last &&
+      last.type === 'run' &&
+      last.kind === entry.kind &&
+      last.target === entry.target
+    ) {
+      last.count += 1;
+      last.oldestAt = entry.createdAt;
+    } else if (
+      last &&
+      last.type === 'single' &&
+      last.entry.kind === entry.kind &&
+      last.entry.target === entry.target
+    ) {
+      // Promote the singleton to a run.
+      out[out.length - 1] = {
+        type: 'run',
+        key: last.entry.id,
+        kind: last.entry.kind,
+        target: last.entry.target,
+        count: 2,
+        newest: last.entry,
+        oldestAt: entry.createdAt,
+      };
+    } else {
+      out.push({ type: 'single', key: entry.id, entry });
+    }
+  }
+  return out;
+}
+
+// --- row rendering ---
+
+function ActivityRow({ row }: { row: Row }) {
+  if (row.type === 'run') {
+    return <RunRow row={row} />;
+  }
+  const { entry } = row;
+  switch (entry.kind) {
+    case 'secret_use':
+      return <SecretUseRow entry={entry} count={1} />;
+    case 'mcp_call':
+      return <McpCallRow entry={entry} count={1} />;
+    case 'cmd_exec':
+      return <CmdExecRow entry={entry} />;
+    default:
+      return <GenericRow entry={entry} />;
+  }
+}
+
+function RunRow({ row }: { row: Extract<Row, { type: 'run' }> }) {
+  // Use the newest entry's `id` as the React key; the count badge encodes
+  // the rest. We surface both endpoints of the run so a quick glance shows
+  // the time window the agent was burning through this resource.
+  switch (row.kind) {
+    case 'secret_use':
+      return <SecretUseRow entry={row.newest} count={row.count} oldestAt={row.oldestAt} />;
+    case 'mcp_call':
+      return <McpCallRow entry={row.newest} count={row.count} oldestAt={row.oldestAt} />;
+    default:
+      return (
+        <li className="activity-row">
+          <ActivityIcon kind={row.kind} />
+          <div className="activity-body">
+            <div className="activity-headline">
+              <code>{row.target}</code>
+              <span className="tag muted">×{row.count}</span>
+            </div>
+            <RowMeta newest={row.newest} oldestAt={row.oldestAt} />
+          </div>
+        </li>
+      );
+  }
+}
+
+function SecretUseRow({
+  entry,
+  count,
+  oldestAt,
+}: {
+  entry: ActivityEntry;
+  count: number;
+  oldestAt?: string;
+}) {
+  return (
+    <li className="activity-row">
+      <ActivityIcon kind="secret_use" />
+      <div className="activity-body">
+        <div className="activity-headline">
+          <span className="activity-kind-label">Secret</span>
+          <code>{entry.target}</code>
+          {count > 1 && <span className="tag muted">used ×{count}</span>}
+          {count === 1 && <span className="dim">used</span>}
+        </div>
+        {entry.summary && <div className="activity-summary">{entry.summary}</div>}
+        <RowMeta newest={entry} oldestAt={oldestAt} />
+      </div>
+    </li>
+  );
+}
+
+function McpCallRow({
+  entry,
+  count,
+  oldestAt,
+}: {
+  entry: ActivityEntry;
+  count: number;
+  oldestAt?: string;
+}) {
+  return (
+    <li className="activity-row">
+      <ActivityIcon kind="mcp_call" />
+      <div className="activity-body">
+        <div className="activity-headline">
+          <span className="activity-kind-label">MCP</span>
+          <code>{entry.target}</code>
+          {count > 1 && <span className="tag muted">called ×{count}</span>}
+          {count === 1 && <span className="dim">called</span>}
+        </div>
+        {entry.summary && <div className="activity-summary">{entry.summary}</div>}
+        <RowMeta newest={entry} oldestAt={oldestAt} />
+      </div>
+    </li>
+  );
+}
+
+function CmdExecRow({ entry }: { entry: ActivityEntry }) {
+  // The server's contract has the command in `target` and the output preview
+  // in `summary`. We render the command in a code block and truncate output
+  // visually (CSS), but also clamp the underlying string so we don't ship
+  // megabytes of stdout into the DOM if a server bug drops the truncation.
+  const preview = entry.summary
+    ? entry.summary.length > CMD_PREVIEW_CHARS
+      ? entry.summary.slice(0, CMD_PREVIEW_CHARS) + '…'
+      : entry.summary
+    : null;
+  return (
+    <li className="activity-row">
+      <ActivityIcon kind="cmd_exec" />
+      <div className="activity-body">
+        <div className="activity-headline">
+          <span className="activity-kind-label">Cmd</span>
+          <code className="activity-cmd">{entry.target}</code>
+        </div>
+        {preview && <pre className="activity-cmd-output">{preview}</pre>}
+        <RowMeta newest={entry} />
+      </div>
+    </li>
+  );
+}
+
+function GenericRow({ entry }: { entry: ActivityEntry }) {
+  return (
+    <li className="activity-row">
+      <ActivityIcon kind={entry.kind} />
+      <div className="activity-body">
+        <div className="activity-headline">
+          <span className="activity-kind-label">{entry.kind}</span>
+          {entry.target && <code>{entry.target}</code>}
+        </div>
+        {entry.summary && <div className="activity-summary">{entry.summary}</div>}
+        <RowMeta newest={entry} />
+      </div>
+    </li>
+  );
+}
+
+function RowMeta({ newest, oldestAt }: { newest: ActivityEntry; oldestAt?: string }) {
+  const newestAbs = new Date(newest.createdAt).toLocaleString();
+  return (
+    <div className="activity-meta">
+      <span title={newestAbs}>{formatRelative(newest.createdAt)}</span>
+      {oldestAt && oldestAt !== newest.createdAt && (
+        <span className="dim" title={new Date(oldestAt).toLocaleString()}>
+          {' '}
+          · since {formatRelative(oldestAt)}
+        </span>
+      )}
+      {newest.sessionId && (
+        <span className="dim">
+          {' '}
+          · session <code>{newest.sessionId.slice(0, 8)}</code>
+        </span>
+      )}
+    </div>
+  );
+}
+
+// Tiny inline icons — kept inside this file so the activity feed has a
+// single dependency footprint. Sized 1em via stroke-width so they pick up
+// the surrounding text color.
+function ActivityIcon({ kind }: { kind: string }) {
+  const className = `activity-icon activity-icon-${iconClass(kind)}`;
+  switch (kind) {
+    case 'secret_use':
+      return (
+        <svg className={className} viewBox="0 0 16 16" aria-hidden="true">
+          <circle cx="6" cy="8" r="3" fill="none" stroke="currentColor" strokeWidth="1.4" />
+          <path d="M9 8h5M12 8v3M14 8v2" stroke="currentColor" strokeWidth="1.4" fill="none" strokeLinecap="round" />
+        </svg>
+      );
+    case 'mcp_call':
+      return (
+        <svg className={className} viewBox="0 0 16 16" aria-hidden="true">
+          <path
+            d="M3 6.5l3-3 1.5 1.5-3 3zm5.5-2L13 9l-1.5 1.5L7 6zM4.5 8.5L7 11l-2.5 2.5L2 11z"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.4"
+            strokeLinejoin="round"
+          />
+        </svg>
+      );
+    case 'cmd_exec':
+      return (
+        <svg className={className} viewBox="0 0 16 16" aria-hidden="true">
+          <path
+            d="M3 4l3 4-3 4M8 12h6"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.4"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      );
+    default:
+      return (
+        <svg className={className} viewBox="0 0 16 16" aria-hidden="true">
+          <circle cx="8" cy="8" r="2" fill="currentColor" />
+        </svg>
+      );
+  }
+}
+
+function iconClass(kind: string): string {
+  switch (kind) {
+    case 'secret_use':
+      return 'secret';
+    case 'mcp_call':
+      return 'mcp';
+    case 'cmd_exec':
+      return 'cmd';
+    default:
+      return 'generic';
+  }
+}

--- a/web/ui/src/components/ActivityFeed.tsx
+++ b/web/ui/src/components/ActivityFeed.tsx
@@ -26,39 +26,86 @@ interface ActivityFeedProps {
   folder: string;
 }
 
+// 404 from the activity endpoint means the server hasn't shipped the route
+// yet (UI lands ahead of paraclaw-server's PR2 by design). Render a graceful
+// note rather than the raw status string.
+function isNotFoundError(err: unknown): boolean {
+  return err instanceof Error && /\b404\b|not\s*found/i.test(err.message);
+}
+
+const NOT_AVAILABLE_MESSAGE = 'Activity log not available on this server.';
+
 export function ActivityFeed({ folder }: ActivityFeedProps) {
   const [items, setItems] = useState<ActivityEntry[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [notAvailable, setNotAvailable] = useState(false);
   const [loading, setLoading] = useState(true);
 
+  // `reload` itself doesn't carry a cancelled flag — it's invoked from the
+  // effects below (which do), and from the Retry button (where there's no
+  // unmount race because the click and the response live in the same render).
   const reload = useCallback(async () => {
     try {
       const rows = await listGroupActivity(folder, { limit: PAGE_SIZE });
       setItems(rows);
       setError(null);
+      setNotAvailable(false);
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      if (isNotFoundError(err)) {
+        setNotAvailable(true);
+        setError(null);
+      } else {
+        setError(err instanceof Error ? err.message : String(err));
+      }
     } finally {
       setLoading(false);
     }
   }, [folder]);
 
   useEffect(() => {
-    void reload();
-  }, [reload]);
+    let cancelled = false;
+    listGroupActivity(folder, { limit: PAGE_SIZE })
+      .then((rows) => {
+        if (cancelled) return;
+        setItems(rows);
+        setError(null);
+        setNotAvailable(false);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        if (isNotFoundError(err)) {
+          setNotAvailable(true);
+          setError(null);
+        } else {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [folder]);
 
   // Background poll — silent on failure. The 15s cadence is conservative
   // (this is an audit log, not a chat scroll); user can refresh manually if
   // they're watching live.
   useEffect(() => {
-    if (error) return;
+    if (error || notAvailable) return;
+    let cancelled = false;
     const t = setInterval(() => {
       listGroupActivity(folder, { limit: PAGE_SIZE })
-        .then((rows) => setItems(rows))
+        .then((rows) => {
+          if (!cancelled) setItems(rows);
+        })
         .catch(() => {});
     }, POLL_MS);
-    return () => clearInterval(t);
-  }, [folder, error]);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, [folder, error, notAvailable]);
 
   if (loading && !items) {
     return (
@@ -66,6 +113,14 @@ export function ActivityFeed({ folder }: ActivityFeedProps) {
         <div className="skeleton skeleton-line" style={{ width: '40%' }} />
         <div className="skeleton skeleton-line" />
         <div className="skeleton skeleton-line" style={{ width: '70%' }} />
+      </div>
+    );
+  }
+
+  if (notAvailable) {
+    return (
+      <div className="section">
+        <div className="empty">{NOT_AVAILABLE_MESSAGE}</div>
       </div>
     );
   }

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -277,6 +277,52 @@ export async function closeSession(sessionId: string): Promise<{ id: string; sta
   });
 }
 
+// --- Agent activity log ---
+
+/**
+ * Activity entry surfaced from `/api/agent-groups/:folder/activity`.
+ * `kind` is open-ended (the server adds new ones over time), but the UI
+ * has special rendering for the three documented in the PR2 brief:
+ * `secret_use`, `mcp_call`, `cmd_exec`. Anything else falls through to a
+ * generic row.
+ *
+ * `target` is whatever-the-kind-points-at: secret name, tool name, or
+ * the command string. `summary` is the human-readable detail line — the
+ * server is responsible for keeping it short and quotable.
+ */
+export type ActivityKind = 'secret_use' | 'mcp_call' | 'cmd_exec' | string;
+
+export interface ActivityEntry {
+  id: string;
+  agentGroupId: string;
+  /** Null when the event isn't tied to a specific session (rare — most are). */
+  sessionId: string | null;
+  kind: ActivityKind;
+  target: string;
+  summary: string;
+  createdAt: string;
+}
+
+export interface ListActivityOptions {
+  /** ISO8601 — only return entries strictly newer than this. Used for incremental polling. */
+  since?: string;
+  /** Server caps at ~500; default is 100. */
+  limit?: number;
+}
+
+export async function listGroupActivity(
+  folder: string,
+  options: ListActivityOptions = {},
+): Promise<ActivityEntry[]> {
+  const params = new URLSearchParams();
+  if (options.since) params.set('since', options.since);
+  if (options.limit !== undefined) params.set('limit', String(options.limit));
+  const qs = params.toString();
+  const path = `/agent-groups/${encodeURIComponent(folder)}/activity${qs ? `?${qs}` : ''}`;
+  const r = await request<{ activity: ActivityEntry[] }>(path);
+  return r.activity;
+}
+
 // --- Secrets (paraclaw-native, replaces OneCLI proxy) ---
 
 /** Per PRIMITIVES.md §"Secret": kinds keyed by purpose. */

--- a/web/ui/src/routes/GroupDetail.tsx
+++ b/web/ui/src/routes/GroupDetail.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams, useSearchParams } from 'react-router-dom';
+import { ActivityFeed } from '../components/ActivityFeed.tsx';
 import { ScopeGrants, SCOPE_OPTIONS } from '../components/ScopeGrants.tsx';
 import { StatusDot, formatRelative } from '../components/StatusDot.tsx';
 import { VaultPicker } from '../components/VaultPicker.tsx';
@@ -15,8 +16,16 @@ import {
 
 const POLL_MS = 7_000;
 
+type DetailTab = 'overview' | 'activity';
+
+function parseTab(raw: string | null): DetailTab {
+  return raw === 'activity' ? 'activity' : 'overview';
+}
+
 export function GroupDetail() {
   const { folder } = useParams<{ folder: string }>();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tab = parseTab(searchParams.get('tab'));
   const [group, setGroup] = useState<AgentGroupView | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -207,6 +216,28 @@ export function GroupDetail() {
 
       {flash && <div className={flash.kind === 'ok' ? 'status-banner' : 'error-banner'}>{flash.text}</div>}
 
+      <DetailTabs
+        tab={tab}
+        onChange={(next) => {
+          // Preserve any other search params (none today, but future-proof).
+          // The replace param keeps the tab toggle out of browser-history
+          // back-stack noise — flipping tabs shouldn't make Back unintuitive.
+          setSearchParams(
+            (prev) => {
+              const p = new URLSearchParams(prev);
+              if (next === 'overview') p.delete('tab');
+              else p.set('tab', next);
+              return p;
+            },
+            { replace: true },
+          );
+        }}
+      />
+
+      {tab === 'activity' && folder && <ActivityFeed folder={folder} />}
+
+      {tab === 'overview' && (
+      <>
       <div className="section">
         <h3>Agent group</h3>
         <div className="kv">
@@ -359,7 +390,26 @@ export function GroupDetail() {
           .)
         </p>
       </div>
+      </>
+      )}
     </div>
+  );
+}
+
+function DetailTabs({ tab, onChange }: { tab: DetailTab; onChange: (next: DetailTab) => void }) {
+  return (
+    <ol className="detail-tabs">
+      <li className={`detail-tab${tab === 'overview' ? ' active' : ''}`}>
+        <button type="button" onClick={() => onChange('overview')}>
+          Overview
+        </button>
+      </li>
+      <li className={`detail-tab${tab === 'activity' ? ' active' : ''}`}>
+        <button type="button" onClick={() => onChange('activity')}>
+          Activity
+        </button>
+      </li>
+    </ol>
   );
 }
 

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -394,3 +394,114 @@ hr.sep { border: 0; border-top: 1px solid var(--border); margin: 1.5rem 0; }
   padding: 0.5rem 0.7rem;
   border-radius: 6px;
 }
+
+/* Detail tabs (Overview / Activity on group detail page) */
+.detail-tabs {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1.25rem;
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+}
+.detail-tab button {
+  background: transparent;
+  color: var(--fg-muted);
+  border: 0;
+  border-bottom: 2px solid transparent;
+  padding: 0.5rem 1rem;
+  border-radius: 0;
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+.detail-tab button:hover {
+  background: transparent;
+  color: var(--fg);
+}
+.detail-tab.active button {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* Activity feed */
+.activity-feed {
+  padding: 0;
+}
+.activity-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.activity-row {
+  display: flex;
+  gap: 0.85rem;
+  padding: 0.9rem 1.5rem;
+  border-bottom: 1px solid var(--border);
+}
+.activity-row:last-child {
+  border-bottom: 0;
+}
+.activity-icon {
+  flex-shrink: 0;
+  width: 1.1rem;
+  height: 1.1rem;
+  margin-top: 0.15rem;
+  color: var(--fg-muted);
+}
+.activity-icon-secret { color: var(--warn); }
+.activity-icon-mcp    { color: var(--accent); }
+.activity-icon-cmd    { color: var(--fg-muted); }
+.activity-body {
+  flex: 1;
+  min-width: 0;
+}
+.activity-headline {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+  font-size: 0.95rem;
+}
+.activity-kind-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-dim);
+  font-weight: 500;
+}
+.activity-cmd {
+  /* The command can be long — let it wrap rather than scroll horizontally. */
+  word-break: break-all;
+}
+.activity-cmd-output {
+  margin: 0.4rem 0 0;
+  padding: 0.55rem 0.75rem;
+  background: var(--bg-soft);
+  border-left: 2px solid var(--border);
+  border-radius: 4px;
+  font-family: "SF Mono", ui-monospace, Menlo, monospace;
+  font-size: 0.8rem;
+  color: var(--fg-muted);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 6em;
+  overflow: hidden;
+}
+.activity-summary {
+  margin-top: 0.25rem;
+  font-size: 0.88rem;
+  color: var(--fg-muted);
+}
+.activity-meta {
+  margin-top: 0.3rem;
+  font-size: 0.8rem;
+  color: var(--fg-dim);
+}
+.activity-more {
+  padding: 0.85rem 1.5rem;
+  margin: 0;
+  border-top: 1px solid var(--border);
+  font-size: 0.82rem;
+}


### PR DESCRIPTION
> **Stacked on paraclaw-server's `feat/agent-activity-log`; merge in order.**
> The `/api/agent-groups/:folder/activity` endpoint lands in that PR; this consumes it.

## Summary

Adds an **Activity** tab to the agent-group detail page. Reads from the new `GET /api/agent-groups/:folder/activity?since=&limit=` endpoint (paraclaw-server PR2, in flight) and renders an audit-log feed.

### UX shape

- **Tab strip** — Overview / Activity, with the existing sections moved under Overview. Tab state lives in the URL search param (`?tab=activity`) so it's bookmarkable; flipping tabs uses `replace: true` so Back doesn't pile up tab toggles.
- **Per-kind rendering**:
  - `secret_use` → "Secret `<name>` used ×N" with a key icon (warn-tinted).
  - `mcp_call` → "MCP `<tool>` called ×N" with a wrench icon (accent-tinted).
  - `cmd_exec` → command in code, output preview clamped to ~140 chars in a max-6em pre block. Never run-collapsed — each command's output is the signal.
  - other kinds fall through to a generic kind/target/summary row.
- **Run collapse** — adjacent rows with the same `(kind, target)` collapse into one count-badged row. Both endpoints of the run timestamped (`3m ago · since 22m ago`). Keeps a chatty agent that hits one secret 50 times in a row from drowning the next interesting event.
- **Polling** — 15s background refresh, silent on failure. Conservative cadence (this is an audit log, not a chat scroll).
- **Empty / loading / error** states match the rest of the app — skeleton lines, error-banner with Retry, "no activity yet" empty state.

### Server contract consumed

```ts
type ActivityKind = 'secret_use' | 'mcp_call' | 'cmd_exec' | string;
interface ActivityEntry {
  id: string;
  agentGroupId: string;
  sessionId: string | null;
  kind: ActivityKind;
  target: string;
  summary: string;
  createdAt: string;
}
// GET /api/agent-groups/:folder/activity?since=&limit=
//  -> { activity: ActivityEntry[] }   // newest-first
```

`since` is reserved for future incremental polling; today the UI just refetches the latest 100. `limit` defaults server-side to 100; cap surfaced via "Showing the 100 most recent events" footer when at the cap.

## Test plan

- [x] `pnpm exec tsc --noEmit` (root + web/ui) clean
- [x] `pnpm build` (web/ui) — verify-base passes, dist references `/claw/`-prefixed assets
- [x] `pnpm test` (server) — 261/261 pass (no server-side changes in this PR)
- [ ] Manual smoke at `/claw/groups/:folder?tab=activity` once paraclaw-server's endpoint lands and `night/paraclaw-rebirth` rebuilds locally
- [ ] Verify run-collapse rendering against real data (mock-data sketch deferred — server endpoint will arrive shortly)

## Notes for reviewer

- `ActivityFeed.tsx` is self-contained (~280 LOC) — pure presentation + one fetch hook. The collapse logic in `collapseRuns()` is pure and testable; happy to add a vitest for it if the team adopts UI tests, but the UI tree currently has none and adding test infra is out of scope for this PR.
- Three-letter kind labels (Secret / MCP / Cmd) chosen so they read as a column not a sentence — keeps the eye scanning vertically through the feed.
- Inline SVG icons rather than a font/icon-package — same reasoning as elsewhere in the UI: keeps the bundle untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)